### PR TITLE
#440 Throttle Azure IoT Hub (MQTT) sending on overload

### DIFF
--- a/doc/mqtt-throttling.md
+++ b/doc/mqtt-throttling.md
@@ -185,13 +185,68 @@ Notes:
 - `isHealthy()` still returns `true` unconditionally — that is intentionally left for #441.
   Do not rely on `isHealthy()` for overload detection yet; use the failure counters instead.
 
-## Hooks left for #440 and #441
+## Hooks left for #441
 
-- **#440 (throttle):** read the returned `MqttSendFailureType` (and `isRetryable()`) to drive
-  back-off; configure a bounded SDK retry policy via `AzureDeviceClient`.
 - **#441 (stop):** when `getLastFailureType() == QUOTA_EXCEEDED` (or repeated `THROTTLED`),
-  flip a real health flag so `publish()` pauses/rejects new sends, and make `isHealthy()`
-  reflect it.
+  flip a real health flag so `publish()` pauses/rejects new sends, switch the SDK to `NoRetry`
+  via `AzureDeviceClient.setRetryPolicy(...)`, and make `isHealthy()` reflect it.
+
+---
+
+# #440 Throttle — implemented
+
+The throttle step **brakes** sending when IoT Hub is overloaded; it does **not** fully stop
+(that is #441). It addresses both retry layers identified above.
+
+## Layer 1 — bounded SDK retry policy (`AzureDeviceClient`)
+
+The runaway "same message retried ~23 times" came from the SDK's default
+`ExponentialBackoffWithJitter`, which retries ~`Integer.MAX_VALUE` times. `AzureDeviceClient`
+now installs a **bounded** policy on construction via `deviceClient.setRetryPolicy(...)`:
+
+| Setting            | Default | Constant in `AzureDeviceClient` |
+|--------------------|---------|---------------------------------|
+| max retries        | 3       | `DEFAULT_MAX_RETRIES`           |
+| min backoff (ms)   | 100     | `DEFAULT_MIN_BACKOFF_MILLIS`    |
+| max backoff (ms)   | 10 000  | `DEFAULT_MAX_BACKOFF_MILLIS`    |
+| backoff delta (ms) | 100     | `DEFAULT_BACKOFF_DELTA_MILLIS`  |
+
+`AzureDeviceClient.setRetryPolicy(RetryPolicy)` is also exposed so #441 can switch to `NoRetry`
+on `QUOTA_EXCEEDED`.
+
+## Layer 2 — adaptive app-level back-off (`MqttSendThrottle`)
+
+`MqttSendThrottle` (`no.cantara.realestate.azure.iot`) keeps an exponential back-off window
+driven by the #439 classification:
+
+- an **overload** outcome (`THROTTLED` / `QUOTA_EXCEEDED`, i.e. `isOverload()`) escalates the
+  window: `base * 2^(consecutive-1)`, capped at max (defaults 1 s base, 60 s cap);
+- a **success** (`NONE`) resets it immediately;
+- other failures leave the window to expire on its own.
+
+`AzureObservationDistributionClient.publish()` calls `applyBackpressureIfThrottled()` on the
+distributor thread before each send; when a window is active it sleeps for the remaining delay,
+which naturally brakes the whole pipeline. The throttle is fed from the send callback
+(`recordOutcome(NONE)` on success, `recordOutcome(type)` on failure).
+
+## How to use it (for client applications)
+
+```java
+AzureObservationDistributionClient client = ...;
+
+client.isThrottled();              // true while braking due to overload
+client.getThrottleBackoffMillis(); // remaining brake delay in ms (0 when not throttled)
+client.getConsecutiveOverloads();  // overload responses since last success (resets on success)
+```
+
+Notes:
+
+- The brake runs on the **distributor thread** — while throttled, observations accumulate in
+  the upstream `ObservationsRepository` queue (bounded; see the silent-drop analysis). This is
+  intended braking; the hard stop is #441.
+- Defaults are constants, not yet externally configurable — tune in code or follow up with
+  config keys if ops needs it.
+- `isHealthy()` still returns `true` — unchanged, still left for #441.
 
 ---
 

--- a/src/main/java/no/cantara/realestate/azure/AzureObservationDistributionClient.java
+++ b/src/main/java/no/cantara/realestate/azure/AzureObservationDistributionClient.java
@@ -21,6 +21,7 @@ import no.cantara.realestate.RealEstateException;
 import no.cantara.realestate.azure.iot.AzureDeviceClient;
 import no.cantara.realestate.azure.iot.MqttSendFailureClassifier;
 import no.cantara.realestate.azure.iot.MqttSendFailureType;
+import no.cantara.realestate.azure.iot.MqttSendThrottle;
 import no.cantara.realestate.azure.rec.RecObservationMessage;
 import no.cantara.realestate.distribution.ObservationDistributionClient;
 import no.cantara.realestate.json.RealEstateObjectMapper;
@@ -55,6 +56,10 @@ public class AzureObservationDistributionClient implements ObservationDistributi
     private final Map<MqttSendFailureType, Long> failuresByType = new EnumMap<>(MqttSendFailureType.class);
     private volatile MqttSendFailureType lastFailureType = MqttSendFailureType.NONE;
     private volatile Instant lastFailureAt = null;
+
+    // Adaptive back-off (issue #440). Brakes the send rate when IoT Hub reports overload
+    // (THROTTLED/QUOTA_EXCEEDED) and recovers automatically on success.
+    private final MqttSendThrottle sendThrottle = new MqttSendThrottle();
 
     private final Tracer tracer;
     private final TelemetryClient telemetryClient;
@@ -149,6 +154,7 @@ public class AzureObservationDistributionClient implements ObservationDistributi
                 log.trace("Missing observations message, not able to publish");
                 return;
             }
+            applyBackpressureIfThrottled();
             boolean success = false;
             Span childSpan = tracer.spanBuilder("SendTelemetry").setSpanKind(SpanKind.CLIENT).startSpan();
             childSpan.setAttribute("appName", "IoTHubClient");
@@ -197,6 +203,7 @@ public class AzureObservationDistributionClient implements ObservationDistributi
                             childSpan.setAttribute("http.response.status_code", "200");
                             childSpan.addEvent("Message sent");
                             addMessagesPublished();
+                            sendThrottle.recordOutcome(MqttSendFailureType.NONE);
                         }
                         log.debug("Observation - Response from IoT Hub: message Id={}, status={}", msg.getMessageId(), iotHubClientException == null ? OK : iotHubClientException.getStatusCode());
                         messageSent(sentMessage);
@@ -352,9 +359,9 @@ public class AzureObservationDistributionClient implements ObservationDistributi
      * logs at a severity that matches the category. Returns the detected type so the caller can
      * annotate telemetry/spans.
      *
-     * <p>This method only <em>detects and reports</em>. Backing off (#440) and stopping new sends
-     * (#441) are deliberately left out — they will hook into the {@link MqttSendFailureType}
-     * returned here and the counters exposed by {@link #getFailureCountsByType()}.
+     * <p>Detection (#439) feeds the adaptive back-off (#440): the classified type is handed to
+     * {@link #sendThrottle}, which escalates the brake on overload responses. Stopping new sends
+     * outright (#441) is still left out.
      */
     synchronized MqttSendFailureType registerFailure(IotHubClientException exception, ObservationMessage observationMessage) {
         MqttSendFailureType failureType = MqttSendFailureClassifier.classify(exception);
@@ -362,6 +369,7 @@ public class AzureObservationDistributionClient implements ObservationDistributi
         lastFailureType = failureType;
         lastFailureAt = Instant.ofEpochMilli(System.currentTimeMillis());
         addMessagesFailed();
+        sendThrottle.recordOutcome(failureType);
         IotHubStatusCode statusCode = exception == null ? null : exception.getStatusCode();
         switch (failureType) {
             case QUOTA_EXCEEDED:
@@ -417,6 +425,49 @@ public class AzureObservationDistributionClient implements ObservationDistributi
      */
     public Instant getLastFailureAt() {
         return lastFailureAt;
+    }
+
+    /**
+     * Brake the send rate when IoT Hub is signalling overload (issue #440). Called at the start of
+     * {@link #publish(ObservationMessage)} on the distributor thread, so braking here naturally
+     * slows the whole pipeline. When not throttled the delay is {@code 0} and this is a no-op.
+     */
+    protected void applyBackpressureIfThrottled() {
+        long delayMillis = sendThrottle.currentBackoffDelayMillis();
+        if (delayMillis <= 0) {
+            return;
+        }
+        log.warn("Braking Azure IoT Hub sending for {} ms after {} consecutive overload responses",
+                delayMillis, sendThrottle.getConsecutiveOverloads());
+        telemetryClient.trackEvent("throttle-backpressure-applied");
+        try {
+            Thread.sleep(delayMillis);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+    }
+
+    /**
+     * @return milliseconds the client is currently braking before the next send ({@code 0} when not
+     * throttled). A non-zero value means IoT Hub recently reported overload.
+     */
+    public long getThrottleBackoffMillis() {
+        return sendThrottle.currentBackoffDelayMillis();
+    }
+
+    /**
+     * @return {@code true} if sending is currently being braked due to IoT Hub overload (#440).
+     */
+    public boolean isThrottled() {
+        return sendThrottle.isThrottled();
+    }
+
+    /**
+     * @return the number of consecutive overload responses (THROTTLED/QUOTA_EXCEEDED) since the
+     * last successful send. Resets to 0 on success.
+     */
+    public int getConsecutiveOverloads() {
+        return sendThrottle.getConsecutiveOverloads();
     }
 
     @Override

--- a/src/main/java/no/cantara/realestate/azure/iot/AzureDeviceClient.java
+++ b/src/main/java/no/cantara/realestate/azure/iot/AzureDeviceClient.java
@@ -2,6 +2,8 @@ package no.cantara.realestate.azure.iot;
 
 import com.microsoft.azure.sdk.iot.device.*;
 import com.microsoft.azure.sdk.iot.device.exceptions.IotHubClientException;
+import com.microsoft.azure.sdk.iot.device.transport.ExponentialBackoffWithJitter;
+import com.microsoft.azure.sdk.iot.device.transport.RetryPolicy;
 import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.SpanKind;
@@ -16,6 +18,15 @@ import static org.slf4j.LoggerFactory.getLogger;
 public class AzureDeviceClient {
     private static final Logger log = getLogger(AzureDeviceClient.class);
 
+    // Bounded retry policy (issue #440). The SDK default ExponentialBackoffWithJitter retries
+    // ~Integer.MAX_VALUE times, which is the source of the "same message retried ~23 times" runaway
+    // that DoS-es us against IoT Hub. Cap the attempts so the SDK gives up and hands control back
+    // to the application-level throttle/stop logic.
+    static final int DEFAULT_MAX_RETRIES = 3;
+    static final long DEFAULT_MIN_BACKOFF_MILLIS = 100L;
+    static final long DEFAULT_MAX_BACKOFF_MILLIS = 10_000L;
+    static final long DEFAULT_BACKOFF_DELTA_MILLIS = 100L;
+
     private final DeviceClient deviceClient;
     private final Tracer tracer;
 
@@ -29,6 +40,7 @@ public class AzureDeviceClient {
         if (deviceClient != null && deviceClient.getConfig() != null) {
             iotHubHostname = deviceClient.getConfig().getIotHubHostname();
         }
+        applyBoundedRetryPolicy();
         tracer = GlobalOpenTelemetry.getTracer(INSTRUMENTATION_SCOPE_NAME);
     }
 
@@ -40,7 +52,37 @@ public class AzureDeviceClient {
         if (deviceClient != null && deviceClient.getConfig() != null) {
             iotHubHostname = deviceClient.getConfig().getIotHubHostname();
         }
+        applyBoundedRetryPolicy();
         tracer = GlobalOpenTelemetry.getTracer(INSTRUMENTATION_SCOPE_NAME);
+    }
+
+    /**
+     * Replace the SDK's effectively-infinite default retry policy with a bounded one, so a single
+     * message is retried only a handful of times before the SDK gives up (issue #440).
+     */
+    private void applyBoundedRetryPolicy() {
+        if (deviceClient == null) {
+            return;
+        }
+        RetryPolicy boundedPolicy = new ExponentialBackoffWithJitter(
+                DEFAULT_MAX_RETRIES,
+                DEFAULT_MIN_BACKOFF_MILLIS,
+                DEFAULT_MAX_BACKOFF_MILLIS,
+                DEFAULT_BACKOFF_DELTA_MILLIS,
+                true);
+        deviceClient.setRetryPolicy(boundedPolicy);
+        log.info("Configured bounded IoT Hub retry policy: maxRetries={}, minBackoffMillis={}, maxBackoffMillis={}",
+                DEFAULT_MAX_RETRIES, DEFAULT_MIN_BACKOFF_MILLIS, DEFAULT_MAX_BACKOFF_MILLIS);
+    }
+
+    /**
+     * Override the SDK retry policy. Used by #441 to switch to {@code NoRetry} when the device
+     * message quota is exhausted, and available for tuning/testing.
+     */
+    public void setRetryPolicy(RetryPolicy retryPolicy) {
+        if (deviceClient != null && retryPolicy != null) {
+            deviceClient.setRetryPolicy(retryPolicy);
+        }
     }
 
     public void openConnection() {

--- a/src/main/java/no/cantara/realestate/azure/iot/MqttSendThrottle.java
+++ b/src/main/java/no/cantara/realestate/azure/iot/MqttSendThrottle.java
@@ -1,0 +1,101 @@
+package no.cantara.realestate.azure.iot;
+
+import java.util.function.LongSupplier;
+
+/**
+ * Adaptive, application-level back-off for Azure IoT Hub sending (issue #440).
+ *
+ * <p>This is the "brake existing sendings" half of overload prevention. It does <strong>not</strong>
+ * stop sending (that is #441) — it slows the send rate when IoT Hub signals overload, and lets it
+ * recover automatically.
+ *
+ * <p>It reacts to the {@link MqttSendFailureType} produced by the detection step (#439):
+ * <ul>
+ *     <li>An {@link MqttSendFailureType#isOverload() overload} response
+ *     ({@code THROTTLED} / {@code QUOTA_EXCEEDED}) escalates the back-off window exponentially.</li>
+ *     <li>A successful send ({@link MqttSendFailureType#NONE}) resets the back-off immediately.</li>
+ *     <li>Other failures leave the window to expire on its own.</li>
+ * </ul>
+ *
+ * <p>Callers poll {@link #currentBackoffDelayMillis()} before sending and brake (e.g. sleep) for
+ * the returned duration. The class is thread-safe: {@link #recordOutcome} is typically called from
+ * the IoT Hub send callback thread while {@link #currentBackoffDelayMillis()} is read from the
+ * distributor thread.
+ */
+public class MqttSendThrottle {
+
+    /** Back-off after the first overload response; doubles per consecutive overload. */
+    public static final long DEFAULT_BASE_BACKOFF_MILLIS = 1_000L;
+    /** Upper bound on the back-off window. */
+    public static final long DEFAULT_MAX_BACKOFF_MILLIS = 60_000L;
+
+    private final long baseBackoffMillis;
+    private final long maxBackoffMillis;
+    private final LongSupplier clockMillis;
+
+    private int consecutiveOverloads = 0;
+    private volatile long throttleUntilMillis = 0L;
+
+    public MqttSendThrottle() {
+        this(DEFAULT_BASE_BACKOFF_MILLIS, DEFAULT_MAX_BACKOFF_MILLIS, System::currentTimeMillis);
+    }
+
+    public MqttSendThrottle(long baseBackoffMillis, long maxBackoffMillis) {
+        this(baseBackoffMillis, maxBackoffMillis, System::currentTimeMillis);
+    }
+
+    // Visible for testing — inject a deterministic clock.
+    MqttSendThrottle(long baseBackoffMillis, long maxBackoffMillis, LongSupplier clockMillis) {
+        this.baseBackoffMillis = baseBackoffMillis;
+        this.maxBackoffMillis = maxBackoffMillis;
+        this.clockMillis = clockMillis;
+    }
+
+    /**
+     * Update the back-off window based on the outcome of a send.
+     *
+     * @param failureType the classified outcome; {@code null} is ignored
+     */
+    public synchronized void recordOutcome(MqttSendFailureType failureType) {
+        if (failureType == null) {
+            return;
+        }
+        if (failureType.isOverload()) {
+            consecutiveOverloads++;
+            throttleUntilMillis = clockMillis.getAsLong() + computeBackoffMillis(consecutiveOverloads);
+        } else if (failureType == MqttSendFailureType.NONE) {
+            consecutiveOverloads = 0;
+            throttleUntilMillis = 0L;
+        }
+        // TRANSIENT / FATAL / UNKNOWN: leave any active window to expire naturally.
+    }
+
+    // Exponential: base * 2^(consecutive-1), capped at maxBackoffMillis. Guards against overflow.
+    long computeBackoffMillis(int consecutive) {
+        if (consecutive <= 0) {
+            return 0L;
+        }
+        int shift = Math.min(consecutive - 1, 30);
+        long backoff = baseBackoffMillis * (1L << shift);
+        if (backoff <= 0 || backoff > maxBackoffMillis) {
+            backoff = maxBackoffMillis;
+        }
+        return backoff;
+    }
+
+    /**
+     * @return milliseconds the caller should brake before the next send, or {@code 0} if sending
+     * may proceed at full rate.
+     */
+    public synchronized long currentBackoffDelayMillis() {
+        return Math.max(0L, throttleUntilMillis - clockMillis.getAsLong());
+    }
+
+    public synchronized boolean isThrottled() {
+        return currentBackoffDelayMillis() > 0L;
+    }
+
+    public synchronized int getConsecutiveOverloads() {
+        return consecutiveOverloads;
+    }
+}

--- a/src/test/java/no/cantara/realestate/azure/iot/AzureDeviceClientRetryPolicyTest.java
+++ b/src/test/java/no/cantara/realestate/azure/iot/AzureDeviceClientRetryPolicyTest.java
@@ -1,0 +1,30 @@
+package no.cantara.realestate.azure.iot;
+
+import com.microsoft.azure.sdk.iot.device.DeviceClient;
+import com.microsoft.azure.sdk.iot.device.transport.NoRetry;
+import com.microsoft.azure.sdk.iot.device.transport.RetryPolicy;
+import org.junit.jupiter.api.Test;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+class AzureDeviceClientRetryPolicyTest {
+
+    @Test
+    void boundedRetryPolicyIsAppliedOnConstruction() {
+        DeviceClient deviceClient = mock(DeviceClient.class);
+        new AzureDeviceClient(deviceClient);
+        // The SDK default retries ~Integer.MAX_VALUE times; we must override it with a bounded policy.
+        verify(deviceClient).setRetryPolicy(any(RetryPolicy.class));
+    }
+
+    @Test
+    void retryPolicyCanBeOverridden() {
+        DeviceClient deviceClient = mock(DeviceClient.class);
+        AzureDeviceClient client = new AzureDeviceClient(deviceClient);
+        NoRetry noRetry = new NoRetry();
+        client.setRetryPolicy(noRetry);
+        verify(deviceClient).setRetryPolicy(noRetry);
+    }
+}

--- a/src/test/java/no/cantara/realestate/azure/iot/MqttSendThrottleTest.java
+++ b/src/test/java/no/cantara/realestate/azure/iot/MqttSendThrottleTest.java
@@ -1,0 +1,95 @@
+package no.cantara.realestate.azure.iot;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.atomic.AtomicLong;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class MqttSendThrottleTest {
+
+    private final AtomicLong now = new AtomicLong(0);
+
+    private MqttSendThrottle throttle(long base, long max) {
+        return new MqttSendThrottle(base, max, now::get);
+    }
+
+    @Test
+    void noThrottleByDefault() {
+        MqttSendThrottle t = throttle(1000, 60000);
+        assertEquals(0, t.currentBackoffDelayMillis());
+        assertFalse(t.isThrottled());
+        assertEquals(0, t.getConsecutiveOverloads());
+    }
+
+    @Test
+    void overloadStartsBackoff() {
+        MqttSendThrottle t = throttle(1000, 60000);
+        t.recordOutcome(MqttSendFailureType.THROTTLED);
+        assertTrue(t.isThrottled());
+        assertEquals(1000, t.currentBackoffDelayMillis());
+        assertEquals(1, t.getConsecutiveOverloads());
+    }
+
+    @Test
+    void backoffGrowsExponentiallyPerConsecutiveOverload() {
+        MqttSendThrottle t = throttle(1000, 60000);
+        t.recordOutcome(MqttSendFailureType.THROTTLED);      // 1000 * 2^0
+        assertEquals(1000, t.currentBackoffDelayMillis());
+        t.recordOutcome(MqttSendFailureType.QUOTA_EXCEEDED); // 1000 * 2^1
+        assertEquals(2000, t.currentBackoffDelayMillis());
+        t.recordOutcome(MqttSendFailureType.THROTTLED);      // 1000 * 2^2
+        assertEquals(4000, t.currentBackoffDelayMillis());
+    }
+
+    @Test
+    void backoffIsCappedAtMax() {
+        MqttSendThrottle t = throttle(1000, 3000);
+        for (int i = 0; i < 10; i++) {
+            t.recordOutcome(MqttSendFailureType.THROTTLED);
+        }
+        assertEquals(3000, t.currentBackoffDelayMillis());
+    }
+
+    @Test
+    void delayDecaysAsTimePasses() {
+        MqttSendThrottle t = throttle(1000, 60000);
+        t.recordOutcome(MqttSendFailureType.THROTTLED);
+        assertEquals(1000, t.currentBackoffDelayMillis());
+        now.addAndGet(400);
+        assertEquals(600, t.currentBackoffDelayMillis());
+        now.addAndGet(600);
+        assertEquals(0, t.currentBackoffDelayMillis());
+        assertFalse(t.isThrottled());
+    }
+
+    @Test
+    void successResetsBackoff() {
+        MqttSendThrottle t = throttle(1000, 60000);
+        t.recordOutcome(MqttSendFailureType.THROTTLED);
+        t.recordOutcome(MqttSendFailureType.THROTTLED);
+        assertTrue(t.isThrottled());
+        t.recordOutcome(MqttSendFailureType.NONE);
+        assertFalse(t.isThrottled());
+        assertEquals(0, t.getConsecutiveOverloads());
+    }
+
+    @Test
+    void nonOverloadFailuresDoNotEscalateOrReset() {
+        MqttSendThrottle t = throttle(1000, 60000);
+        t.recordOutcome(MqttSendFailureType.THROTTLED); // window = 1000
+        t.recordOutcome(MqttSendFailureType.TRANSIENT); // no change
+        t.recordOutcome(MqttSendFailureType.FATAL);     // no change
+        assertEquals(1, t.getConsecutiveOverloads());
+        assertEquals(1000, t.currentBackoffDelayMillis());
+    }
+
+    @Test
+    void nullOutcomeIsIgnored() {
+        MqttSendThrottle t = throttle(1000, 60000);
+        t.recordOutcome(null);
+        assertFalse(t.isThrottled());
+    }
+}


### PR DESCRIPTION
Closes #440. Part of #438. Builds on #439 (detection).

## What this does
**Brakes** Azure IoT Hub (MQTT) sending when IoT Hub signals overload. It does **not** fully stop sending — that is #441. It addresses both retry layers identified in the analysis (`doc/mqtt-throttling.md`).

## Layer 1 — bounded SDK retry policy (`AzureDeviceClient`)
The "same message retried ~23 times" runaway came from the SDK's default `ExponentialBackoffWithJitter`, which retries ~`Integer.MAX_VALUE` times. We now install a **bounded** policy on construction via `deviceClient.setRetryPolicy(...)`:

| Setting | Default |
|---|---|
| max retries | 3 |
| min backoff | 100 ms |
| max backoff | 10 000 ms |
| backoff delta | 100 ms |

`setRetryPolicy(RetryPolicy)` is exposed so #441 can switch to `NoRetry` on `QUOTA_EXCEEDED`.

## Layer 2 — adaptive app-level back-off (`MqttSendThrottle`)
A thread-safe, exponential back-off window driven by the #439 classification:
- overload outcome (`THROTTLED`/`QUOTA_EXCEEDED`) escalates: `base * 2^(consecutive-1)`, capped (defaults 1 s base, 60 s cap);
- success (`NONE`) resets it immediately;
- other failures leave the window to expire.

`publish()` calls `applyBackpressureIfThrottled()` on the distributor thread, so braking naturally slows the whole pipeline. The throttle is fed from the send callback.

## Consumer API
```java
client.isThrottled();
client.getThrottleBackoffMillis();
client.getConsecutiveOverloads();
```

## Tests
`MqttSendThrottleTest` (8) + `AzureDeviceClientRetryPolicyTest` (2). Full suite green: `Tests run: 28, Failures: 0, Errors: 0`.

## Notes / follow-ups
- The brake runs on the distributor thread; while throttled, observations accumulate in the upstream bounded queue. Intended braking — hard stop is #441.
- Defaults are constants, not yet externally configurable (follow-up if ops needs tuning).
- `isHealthy()` still returns `true` — unchanged, left for #441.
- `MESSAGE_EXPIRED`/`MESSAGE_CANCELLED_ONCLOSE` are classified `TRANSIENT` and do not escalate the throttle (only `isOverload()` types do), so the edge case noted on #440 does not affect back-off here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
