### PR TITLE
#441 Stop Azure IoT Hub (MQTT) sending on persistent overload

### DIFF
--- a/doc/mqtt-throttling.md
+++ b/doc/mqtt-throttling.md
@@ -182,14 +182,8 @@ Notes:
 - `getLastFailureType()` / `getLastFailureAt()` are read without locking (`volatile`); the
   count getters return a consistent snapshot.
 - A rising `QUOTA_EXCEEDED` or `THROTTLED` count is the signal that IoT Hub is overloaded.
-- `isHealthy()` still returns `true` unconditionally — that is intentionally left for #441.
-  Do not rely on `isHealthy()` for overload detection yet; use the failure counters instead.
-
-## Hooks left for #441
-
-- **#441 (stop):** when `getLastFailureType() == QUOTA_EXCEEDED` (or repeated `THROTTLED`),
-  flip a real health flag so `publish()` pauses/rejects new sends, switch the SDK to `NoRetry`
-  via `AzureDeviceClient.setRetryPolicy(...)`, and make `isHealthy()` reflect it.
+- For the *health* of sending (stopped or not), use `isHealthy()` / `isSendingStopped()` — wired
+  by #441 (below). The per-category counters remain the finest-grained overload signal.
 
 ---
 
@@ -246,7 +240,62 @@ Notes:
   intended braking; the hard stop is #441.
 - Defaults are constants, not yet externally configurable — tune in code or follow up with
   config keys if ops needs it.
-- `isHealthy()` still returns `true` — unchanged, still left for #441.
+- `isHealthy()` is now made meaningful by #441 (see below).
+
+---
+
+# #441 Stop — implemented
+
+The stop step is the **hard stop** that complements the #440 brake: when IoT Hub overload is
+not transient, new sends are rejected outright until sending recovers. `isHealthy()` now
+reflects this.
+
+## Circuit breaker (`MqttSendCircuitBreaker`)
+
+`MqttSendCircuitBreaker` (`no.cantara.realestate.azure.iot`) is a time-based breaker driven by
+the #439 classification:
+
+| Trigger | Action | Default cooldown |
+|---|---|---|
+| `QUOTA_EXCEEDED` (once) | open immediately — quota is gone, retrying can't succeed | 5 min probe cadence |
+| `THROTTLED` ≥ threshold in a row | open — persistent back-pressure, not a one-off | 30 s |
+| success (`NONE`) | close — resume normal sending | — |
+
+Threshold default: **5** consecutive `THROTTLED` (`DEFAULT_THROTTLE_THRESHOLD`).
+
+While **open**, `allowSend()` returns `false`. After the cooldown elapses it allows a single
+**probe** send (pushing the gate forward so probes don't flood while awaiting the async ack);
+a successful probe closes the circuit, a failed one re-opens it.
+
+## Wiring in `AzureObservationDistributionClient`
+
+- `publish()` checks `circuitBreaker.allowSend()` first; when open it calls `rejectSend(...)` —
+  the message is **dropped on purpose**, but counted (`getNumberOfMessagesRejected()`) and
+  logged, so the loss is **defined and observable, never silent**. Buffering was rejected
+  (OOM risk) and retrying is the very self-DoS being prevented.
+- On `QUOTA_EXCEEDED` the SDK retry policy is switched to `NoRetry`
+  (`AzureDeviceClient.useNoRetryPolicy()`); on recovery the bounded policy (#440) is restored
+  (`useDefaultRetryPolicy()`).
+- **`isHealthy()` now returns `false` while the circuit is open.** A short adaptive brake (#440)
+  does *not* make the client unhealthy — only a hard stop does.
+
+## How to use it (for client applications)
+
+```java
+AzureObservationDistributionClient client = ...;
+
+client.isHealthy();                  // false while sending is stopped (circuit open)
+client.isSendingStopped();           // same signal, affirmative naming
+client.getSendStoppedReason();       // QUOTA_EXCEEDED / THROTTLED, or null when healthy
+client.getNumberOfMessagesRejected();// messages dropped because sending was stopped
+```
+
+Notes:
+
+- Rejected messages are **lost by design** during a stop — monitor
+  `getNumberOfMessagesRejected()` and `isHealthy()`/`getSendStoppedReason()` and alert on them.
+- Recovery is automatic: a probe send after the cooldown closes the circuit on success.
+- Cooldowns/threshold are constants, not yet externally configurable.
 
 ---
 

--- a/src/main/java/no/cantara/realestate/azure/AzureObservationDistributionClient.java
+++ b/src/main/java/no/cantara/realestate/azure/AzureObservationDistributionClient.java
@@ -19,6 +19,7 @@ import io.opentelemetry.context.Scope;
 import no.cantara.realestate.ExceptionStatusType;
 import no.cantara.realestate.RealEstateException;
 import no.cantara.realestate.azure.iot.AzureDeviceClient;
+import no.cantara.realestate.azure.iot.MqttSendCircuitBreaker;
 import no.cantara.realestate.azure.iot.MqttSendFailureClassifier;
 import no.cantara.realestate.azure.iot.MqttSendFailureType;
 import no.cantara.realestate.azure.iot.MqttSendThrottle;
@@ -60,6 +61,11 @@ public class AzureObservationDistributionClient implements ObservationDistributi
     // Adaptive back-off (issue #440). Brakes the send rate when IoT Hub reports overload
     // (THROTTLED/QUOTA_EXCEEDED) and recovers automatically on success.
     private final MqttSendThrottle sendThrottle = new MqttSendThrottle();
+
+    // Circuit breaker (issue #441). Hard-stops new sends when the quota is exhausted or throttling
+    // is persistent; rejected messages are counted (not silently lost) and resume on recovery.
+    private final MqttSendCircuitBreaker circuitBreaker = new MqttSendCircuitBreaker();
+    private long numberOfMessagesRejected = 0;
 
     private final Tracer tracer;
     private final TelemetryClient telemetryClient;
@@ -154,6 +160,10 @@ public class AzureObservationDistributionClient implements ObservationDistributi
                 log.trace("Missing observations message, not able to publish");
                 return;
             }
+            if (!circuitBreaker.allowSend()) {
+                rejectSend(observationMessage);
+                return;
+            }
             applyBackpressureIfThrottled();
             boolean success = false;
             Span childSpan = tracer.spanBuilder("SendTelemetry").setSpanKind(SpanKind.CLIENT).startSpan();
@@ -203,7 +213,7 @@ public class AzureObservationDistributionClient implements ObservationDistributi
                             childSpan.setAttribute("http.response.status_code", "200");
                             childSpan.addEvent("Message sent");
                             addMessagesPublished();
-                            sendThrottle.recordOutcome(MqttSendFailureType.NONE);
+                            registerSuccess();
                         }
                         log.debug("Observation - Response from IoT Hub: message Id={}, status={}", msg.getMessageId(), iotHubClientException == null ? OK : iotHubClientException.getStatusCode());
                         messageSent(sentMessage);
@@ -236,9 +246,15 @@ public class AzureObservationDistributionClient implements ObservationDistributi
         return true;
     }
 
+    /**
+     * Reflects whether sending is operational (issue #441). Returns {@code false} while the send
+     * circuit is open — i.e. new messages are being rejected because the IoT Hub device quota is
+     * exhausted or throttling is persistent. A short adaptive brake (#440) does not make the client
+     * unhealthy; only a hard stop does.
+     */
     @Override
     public boolean isHealthy() {
-        return true;
+        return !circuitBreaker.isOpen();
     }
 
     @Override
@@ -370,6 +386,11 @@ public class AzureObservationDistributionClient implements ObservationDistributi
         lastFailureAt = Instant.ofEpochMilli(System.currentTimeMillis());
         addMessagesFailed();
         sendThrottle.recordOutcome(failureType);
+        circuitBreaker.recordOutcome(failureType, sendThrottle.getConsecutiveOverloads());
+        if (failureType == MqttSendFailureType.QUOTA_EXCEEDED && azureDeviceClient != null) {
+            // Quota is gone — stop the SDK from retrying too, until sending recovers.
+            azureDeviceClient.useNoRetryPolicy();
+        }
         IotHubStatusCode statusCode = exception == null ? null : exception.getStatusCode();
         switch (failureType) {
             case QUOTA_EXCEEDED:
@@ -468,6 +489,63 @@ public class AzureObservationDistributionClient implements ObservationDistributi
      */
     public int getConsecutiveOverloads() {
         return sendThrottle.getConsecutiveOverloads();
+    }
+
+    /**
+     * Reject a message because the send circuit is open (issue #441). The message is dropped on
+     * purpose — buffering it risks running out of memory and retrying it is the self-DoS we are
+     * preventing — but it is counted and logged so the loss is defined and observable, never silent.
+     */
+    private void rejectSend(ObservationMessage observationMessage) {
+        addMessagesRejected();
+        telemetryClient.trackEvent("error-publish-observationmessage-circuit-open");
+        log.debug("MQTT send circuit OPEN (reason={}); rejecting observationMessage. Rejected total={}",
+                circuitBreaker.getOpenReason(), numberOfMessagesRejected);
+    }
+
+    /**
+     * Record a successful send: reset the back-off (#440), close the circuit if it was open (#441),
+     * and restore the bounded retry policy if it had been switched to NoRetry on quota exhaustion.
+     */
+    private void registerSuccess() {
+        sendThrottle.recordOutcome(MqttSendFailureType.NONE);
+        boolean wasOpen = circuitBreaker.isOpen();
+        circuitBreaker.recordOutcome(MqttSendFailureType.NONE, 0);
+        if (wasOpen && !circuitBreaker.isOpen() && azureDeviceClient != null) {
+            azureDeviceClient.useDefaultRetryPolicy();
+        }
+    }
+
+    synchronized void addMessagesRejected() {
+        if (numberOfMessagesRejected < Long.MAX_VALUE) {
+            numberOfMessagesRejected++;
+        } else {
+            numberOfMessagesRejected = 1;
+        }
+    }
+
+    /**
+     * @return how many messages were rejected (dropped) because the send circuit was open (#441).
+     * A non-zero, rising value means sending is stopped and observations are being lost.
+     */
+    public long getNumberOfMessagesRejected() {
+        return numberOfMessagesRejected;
+    }
+
+    /**
+     * @return {@code true} if new sends are currently being rejected because IoT Hub is overloaded
+     * (the send circuit is open). Mirrors {@code !isHealthy()}.
+     */
+    public boolean isSendingStopped() {
+        return circuitBreaker.isOpen();
+    }
+
+    /**
+     * @return the failure category that stopped sending ({@code QUOTA_EXCEEDED} or {@code THROTTLED}),
+     * or {@code null} if sending is not stopped.
+     */
+    public MqttSendFailureType getSendStoppedReason() {
+        return circuitBreaker.getOpenReason();
     }
 
     @Override

--- a/src/main/java/no/cantara/realestate/azure/iot/AzureDeviceClient.java
+++ b/src/main/java/no/cantara/realestate/azure/iot/AzureDeviceClient.java
@@ -3,6 +3,7 @@ package no.cantara.realestate.azure.iot;
 import com.microsoft.azure.sdk.iot.device.*;
 import com.microsoft.azure.sdk.iot.device.exceptions.IotHubClientException;
 import com.microsoft.azure.sdk.iot.device.transport.ExponentialBackoffWithJitter;
+import com.microsoft.azure.sdk.iot.device.transport.NoRetry;
 import com.microsoft.azure.sdk.iot.device.transport.RetryPolicy;
 import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.api.trace.Span;
@@ -83,6 +84,24 @@ public class AzureDeviceClient {
         if (deviceClient != null && retryPolicy != null) {
             deviceClient.setRetryPolicy(retryPolicy);
         }
+    }
+
+    /**
+     * Stop the SDK from retrying at all (issue #441). Used when the device message quota is
+     * exhausted ({@code QUOTA_EXCEEDED}): retrying cannot succeed until the quota window resets and
+     * only worsens the self-DoS.
+     */
+    public void useNoRetryPolicy() {
+        setRetryPolicy(new NoRetry());
+        log.warn("Switched IoT Hub retry policy to NoRetry (quota exhausted / sending stopped).");
+    }
+
+    /**
+     * Restore the bounded retry policy (issue #440) — used when sending recovers after having been
+     * stopped by {@link #useNoRetryPolicy()}.
+     */
+    public void useDefaultRetryPolicy() {
+        applyBoundedRetryPolicy();
     }
 
     public void openConnection() {

--- a/src/main/java/no/cantara/realestate/azure/iot/MqttSendCircuitBreaker.java
+++ b/src/main/java/no/cantara/realestate/azure/iot/MqttSendCircuitBreaker.java
@@ -1,0 +1,152 @@
+package no.cantara.realestate.azure.iot;
+
+import org.slf4j.Logger;
+
+import java.util.function.LongSupplier;
+
+import static org.slf4j.LoggerFactory.getLogger;
+
+/**
+ * Stops new Azure IoT Hub sends when IoT Hub is overloaded (issue #441).
+ *
+ * <p>This is the "stop new sendings" half of overload prevention — the hard stop that complements
+ * the adaptive brake in {@link MqttSendThrottle} (#440). It is a time-based circuit breaker driven
+ * by the #439 classification:
+ *
+ * <ul>
+ *     <li>{@link MqttSendFailureType#QUOTA_EXCEEDED} opens the circuit immediately — the device
+ *     message quota is gone, so retrying cannot succeed until the quota window resets.</li>
+ *     <li>{@link MqttSendFailureType#THROTTLED} opens the circuit once it has happened
+ *     {@code throttleThreshold} times in a row (persistent back-pressure, not a one-off).</li>
+ *     <li>A successful send ({@link MqttSendFailureType#NONE}) closes the circuit and resumes
+ *     normal sending.</li>
+ * </ul>
+ *
+ * <p>While the circuit is {@link State#OPEN} {@link #allowSend()} returns {@code false} and the
+ * caller must reject (and account for) the message. After the cooldown elapses a single probe send
+ * is allowed; if it succeeds the circuit closes, otherwise it re-opens. Thread-safe: failures are
+ * recorded from the send-callback thread while {@link #allowSend()} is polled from the distributor
+ * thread.
+ */
+public class MqttSendCircuitBreaker {
+    private static final Logger log = getLogger(MqttSendCircuitBreaker.class);
+
+    public enum State {CLOSED, OPEN}
+
+    /** Probe cadence while the device message quota is exhausted. */
+    public static final long DEFAULT_QUOTA_COOLDOWN_MILLIS = 300_000L; // 5 min
+    /** Consecutive THROTTLED responses before the circuit opens. */
+    public static final int DEFAULT_THROTTLE_THRESHOLD = 5;
+    /** Cooldown after opening due to persistent throttling. */
+    public static final long DEFAULT_THROTTLE_COOLDOWN_MILLIS = 30_000L;
+
+    private final long quotaCooldownMillis;
+    private final int throttleThreshold;
+    private final long throttleCooldownMillis;
+    private final LongSupplier clockMillis;
+
+    private volatile State state = State.CLOSED;
+    private long openUntilMillis = 0L;
+    private long lastCooldownMillis = 0L;
+    private volatile MqttSendFailureType openReason = null;
+
+    public MqttSendCircuitBreaker() {
+        this(DEFAULT_QUOTA_COOLDOWN_MILLIS, DEFAULT_THROTTLE_THRESHOLD, DEFAULT_THROTTLE_COOLDOWN_MILLIS,
+                System::currentTimeMillis);
+    }
+
+    public MqttSendCircuitBreaker(long quotaCooldownMillis, int throttleThreshold, long throttleCooldownMillis) {
+        this(quotaCooldownMillis, throttleThreshold, throttleCooldownMillis, System::currentTimeMillis);
+    }
+
+    // Visible for testing — inject a deterministic clock.
+    MqttSendCircuitBreaker(long quotaCooldownMillis, int throttleThreshold, long throttleCooldownMillis,
+                           LongSupplier clockMillis) {
+        this.quotaCooldownMillis = quotaCooldownMillis;
+        this.throttleThreshold = throttleThreshold;
+        this.throttleCooldownMillis = throttleCooldownMillis;
+        this.clockMillis = clockMillis;
+    }
+
+    /**
+     * @return {@code true} if a send may proceed; {@code false} if the circuit is open and the
+     * message must be rejected. When the cooldown has elapsed this returns {@code true} for a single
+     * probe and pushes the gate forward so probes do not flood while awaiting the async ack.
+     */
+    public synchronized boolean allowSend() {
+        if (state == State.CLOSED) {
+            return true;
+        }
+        long now = clockMillis.getAsLong();
+        if (now < openUntilMillis) {
+            return false;
+        }
+        openUntilMillis = now + lastCooldownMillis;
+        log.info("MQTT send circuit half-open: probing IoT Hub after cooldown (reason={})", openReason);
+        return true;
+    }
+
+    /**
+     * Update circuit state from the outcome of a send.
+     *
+     * @param failureType          the classified outcome ({@code null} is ignored)
+     * @param consecutiveOverloads consecutive overload responses so far (from {@link MqttSendThrottle})
+     */
+    public synchronized void recordOutcome(MqttSendFailureType failureType, int consecutiveOverloads) {
+        if (failureType == null) {
+            return;
+        }
+        switch (failureType) {
+            case QUOTA_EXCEEDED:
+                open(failureType, quotaCooldownMillis);
+                break;
+            case THROTTLED:
+                if (consecutiveOverloads >= throttleThreshold) {
+                    open(failureType, throttleCooldownMillis);
+                }
+                break;
+            case NONE:
+                close();
+                break;
+            default:
+                // TRANSIENT / FATAL / UNKNOWN: not an overload — leave circuit state unchanged.
+        }
+    }
+
+    private void open(MqttSendFailureType reason, long cooldownMillis) {
+        boolean wasClosed = state == State.CLOSED;
+        state = State.OPEN;
+        openReason = reason;
+        lastCooldownMillis = cooldownMillis;
+        openUntilMillis = clockMillis.getAsLong() + cooldownMillis;
+        if (wasClosed) {
+            log.warn("MQTT send circuit OPEN: stopping new sends for {} ms (reason={}). " +
+                    "New messages will be rejected until IoT Hub recovers.", cooldownMillis, reason);
+        }
+    }
+
+    private void close() {
+        if (state == State.OPEN) {
+            log.warn("MQTT send circuit CLOSED: IoT Hub send succeeded, resuming normal sending " +
+                    "(previous reason={}).", openReason);
+        }
+        state = State.CLOSED;
+        openReason = null;
+        openUntilMillis = 0L;
+    }
+
+    public State getState() {
+        return state;
+    }
+
+    public boolean isOpen() {
+        return state == State.OPEN;
+    }
+
+    /**
+     * @return the failure category that opened the circuit, or {@code null} if closed.
+     */
+    public MqttSendFailureType getOpenReason() {
+        return openReason;
+    }
+}

--- a/src/test/java/no/cantara/realestate/azure/AzureObservationDistributionClientCircuitTest.java
+++ b/src/test/java/no/cantara/realestate/azure/AzureObservationDistributionClientCircuitTest.java
@@ -1,0 +1,75 @@
+package no.cantara.realestate.azure;
+
+import com.microsoft.azure.sdk.iot.device.IotHubStatusCode;
+import com.microsoft.azure.sdk.iot.device.exceptions.IotHubClientException;
+import no.cantara.realestate.azure.iot.AzureDeviceClient;
+import no.cantara.realestate.azure.iot.MqttSendFailureType;
+import no.cantara.realestate.observations.ObservationMessage;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static no.cantara.realestate.azure.AzureObservationDistributionClientTest.buildStubObservation;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class AzureObservationDistributionClientCircuitTest {
+
+    AzureDeviceClient azureDeviceClient;
+    AzureObservationDistributionClient distributionClient;
+
+    @BeforeEach
+    void setUp() {
+        azureDeviceClient = mock(AzureDeviceClient.class);
+        when(azureDeviceClient.isConnectionEstablished()).thenReturn(true);
+        distributionClient = new AzureObservationDistributionClient(azureDeviceClient);
+    }
+
+    @Test
+    void healthyAndSendingUntilOverload() {
+        assertTrue(distributionClient.isHealthy());
+        assertFalse(distributionClient.isSendingStopped());
+    }
+
+    @Test
+    void quotaExceededStopsSendingAndMarksUnhealthy() {
+        distributionClient.registerFailure(
+                new IotHubClientException(IotHubStatusCode.QUOTA_EXCEEDED, "quota gone"),
+                buildStubObservation());
+
+        assertTrue(distributionClient.isSendingStopped());
+        assertFalse(distributionClient.isHealthy());
+        assertEquals(MqttSendFailureType.QUOTA_EXCEEDED, distributionClient.getSendStoppedReason());
+        // Quota exhausted -> SDK retries must be disabled too.
+        verify(azureDeviceClient).useNoRetryPolicy();
+    }
+
+    @Test
+    void publishIsRejectedWhileCircuitOpen() {
+        distributionClient.registerFailure(
+                new IotHubClientException(IotHubStatusCode.QUOTA_EXCEEDED, "quota gone"),
+                buildStubObservation());
+
+        ObservationMessage message = buildStubObservation();
+        distributionClient.publish(message);
+
+        assertEquals(1, distributionClient.getNumberOfMessagesRejected());
+        // Rejected, not handed to the device client.
+        verify(azureDeviceClient, never()).sendEventAsync(any(), any());
+    }
+
+    @Test
+    void singleThrottleDoesNotStopSending() {
+        distributionClient.registerFailure(
+                new IotHubClientException(IotHubStatusCode.THROTTLED, "slow down"),
+                buildStubObservation());
+
+        assertFalse(distributionClient.isSendingStopped());
+        assertTrue(distributionClient.isHealthy());
+    }
+}

--- a/src/test/java/no/cantara/realestate/azure/iot/MqttSendCircuitBreakerTest.java
+++ b/src/test/java/no/cantara/realestate/azure/iot/MqttSendCircuitBreakerTest.java
@@ -1,0 +1,104 @@
+package no.cantara.realestate.azure.iot;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.atomic.AtomicLong;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class MqttSendCircuitBreakerTest {
+
+    private final AtomicLong now = new AtomicLong(0);
+
+    private MqttSendCircuitBreaker breaker(long quotaCooldown, int throttleThreshold, long throttleCooldown) {
+        return new MqttSendCircuitBreaker(quotaCooldown, throttleThreshold, throttleCooldown, now::get);
+    }
+
+    @Test
+    void closedAllowsSendByDefault() {
+        MqttSendCircuitBreaker b = breaker(300_000, 5, 30_000);
+        assertTrue(b.allowSend());
+        assertFalse(b.isOpen());
+        assertNull(b.getOpenReason());
+    }
+
+    @Test
+    void quotaExceededOpensImmediatelyAndRejects() {
+        MqttSendCircuitBreaker b = breaker(300_000, 5, 30_000);
+        b.recordOutcome(MqttSendFailureType.QUOTA_EXCEEDED, 1);
+        assertTrue(b.isOpen());
+        assertEquals(MqttSendFailureType.QUOTA_EXCEEDED, b.getOpenReason());
+        assertFalse(b.allowSend(), "must reject while open within cooldown");
+    }
+
+    @Test
+    void throttleBelowThresholdDoesNotOpen() {
+        MqttSendCircuitBreaker b = breaker(300_000, 5, 30_000);
+        b.recordOutcome(MqttSendFailureType.THROTTLED, 4);
+        assertFalse(b.isOpen());
+        assertTrue(b.allowSend());
+    }
+
+    @Test
+    void throttleAtThresholdOpens() {
+        MqttSendCircuitBreaker b = breaker(300_000, 5, 30_000);
+        b.recordOutcome(MqttSendFailureType.THROTTLED, 5);
+        assertTrue(b.isOpen());
+        assertEquals(MqttSendFailureType.THROTTLED, b.getOpenReason());
+    }
+
+    @Test
+    void allowsSingleProbeAfterCooldownThenGatesAgain() {
+        MqttSendCircuitBreaker b = breaker(300_000, 5, 30_000);
+        b.recordOutcome(MqttSendFailureType.QUOTA_EXCEEDED, 1);
+        assertFalse(b.allowSend());
+
+        now.addAndGet(300_000); // cooldown elapsed
+        assertTrue(b.allowSend(), "one probe allowed");
+        assertFalse(b.allowSend(), "further sends gated until next cooldown");
+        assertTrue(b.isOpen(), "still open until a probe succeeds");
+    }
+
+    @Test
+    void successClosesAndResumes() {
+        MqttSendCircuitBreaker b = breaker(300_000, 5, 30_000);
+        b.recordOutcome(MqttSendFailureType.QUOTA_EXCEEDED, 1);
+        now.addAndGet(300_000);
+        assertTrue(b.allowSend()); // probe
+
+        b.recordOutcome(MqttSendFailureType.NONE, 0); // probe succeeded
+        assertFalse(b.isOpen());
+        assertNull(b.getOpenReason());
+        assertTrue(b.allowSend());
+    }
+
+    @Test
+    void failedProbeReopens() {
+        MqttSendCircuitBreaker b = breaker(300_000, 5, 30_000);
+        b.recordOutcome(MqttSendFailureType.QUOTA_EXCEEDED, 1);
+        now.addAndGet(300_000);
+        assertTrue(b.allowSend()); // probe
+
+        b.recordOutcome(MqttSendFailureType.QUOTA_EXCEEDED, 2); // probe failed
+        assertTrue(b.isOpen());
+        assertFalse(b.allowSend());
+    }
+
+    @Test
+    void transientAndFatalDoNotOpen() {
+        MqttSendCircuitBreaker b = breaker(300_000, 5, 30_000);
+        b.recordOutcome(MqttSendFailureType.TRANSIENT, 0);
+        b.recordOutcome(MqttSendFailureType.FATAL, 0);
+        assertFalse(b.isOpen());
+    }
+
+    @Test
+    void nullOutcomeIgnored() {
+        MqttSendCircuitBreaker b = breaker(300_000, 5, 30_000);
+        b.recordOutcome(null, 0);
+        assertFalse(b.isOpen());
+    }
+}


### PR DESCRIPTION
Closes #441. Part of #438. Completes the self-DoS prevention series (after #439 detect, #440 throttle).

## What this does
**Hard-stops** new Azure IoT Hub (MQTT) sends when overload is not transient, and finally makes `isHealthy()` meaningful. Complements the #440 adaptive brake — #440 slows, #441 stops.

## Circuit breaker (`MqttSendCircuitBreaker`)
Time-based breaker driven by the #439 classification:

| Trigger | Action | Default cooldown |
|---|---|---|
| `QUOTA_EXCEEDED` (once) | open immediately — quota gone, retrying can't succeed | 5 min probe cadence |
| `THROTTLED` ≥ threshold in a row | open — persistent back-pressure | 30 s |
| success (`NONE`) | close — resume | — |

Threshold default 5 consecutive `THROTTLED`. While open, sends are rejected; after the cooldown a single **probe** is allowed (gate pushed forward to avoid flooding while awaiting the async ack) — a successful probe closes the circuit, a failed one re-opens it.

## Wiring (`AzureObservationDistributionClient`)
- `publish()` checks the breaker first; when open it **rejects**: the message is dropped on purpose but **counted and logged** (`getNumberOfMessagesRejected()`) — defined and observable, never silent. Buffering was rejected (OOM risk); retrying is the self-DoS being prevented.
- On `QUOTA_EXCEEDED`, the SDK retry policy is switched to `NoRetry` (`AzureDeviceClient.useNoRetryPolicy()`); on recovery the bounded #440 policy is restored.
- **`isHealthy()` now returns `false` while the circuit is open.** A short #440 brake does not make the client unhealthy — only a hard stop does.

## Consumer API
```java
client.isHealthy();                   // false while sending stopped
client.isSendingStopped();
client.getSendStoppedReason();        // QUOTA_EXCEEDED / THROTTLED / null
client.getNumberOfMessagesRejected();
```

## Tests
`MqttSendCircuitBreakerTest` (9) + `AzureObservationDistributionClientCircuitTest` (4). Full suite green: `Tests run: 41, Failures: 0, Errors: 0`.

## Notes / follow-ups
- Rejected messages are **lost by design** during a stop — monitor `getNumberOfMessagesRejected()` and `isHealthy()` and alert.
- **Behavioural change for consumers:** `isHealthy()` is no longer always `true`. Any health check wired to this client will now report unhealthy during a quota/throttle stop — intended, but worth flagging to ops.
- Cooldowns/threshold are constants, not yet externally configurable (follow-up if ops needs tuning — applies to #440 and #441).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
