### PR TITLE
Stabilize Azure IoT Hub MQTT connection on quota/network loss

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>no.cantara.realestate</groupId>
   <artifactId>azure-client-java</artifactId>
-  <version>0.14.0-SNAPSHOT</version>
+  <version>0.14.2-SNAPSHOT</version>
 
   <name>azure-client-java</name>
   <url>https://github.com/Cantara/realestate-azure-client-lib</url>

--- a/pom.xml
+++ b/pom.xml
@@ -214,12 +214,6 @@
 
     <!-- TEST -->
     <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-simple</artifactId>
-      <version>2.0.18</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-classic</artifactId>
       <version>1.5.34</version>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>no.cantara.realestate</groupId>
   <artifactId>azure-client-java</artifactId>
-  <version>0.12.2-SNAPSHOT</version>
+  <version>0.14.0-SNAPSHOT</version>
 
   <name>azure-client-java</name>
   <url>https://github.com/Cantara/realestate-azure-client-lib</url>
@@ -38,12 +38,12 @@
     <dependency>
       <groupId>no.cantara.realestate</groupId>
       <artifactId>typelib-java</artifactId>
-      <version>0.8.14</version>
+      <version>0.9.0</version>
     </dependency>
     <dependency>
       <groupId>no.cantara.realestate</groupId>
       <artifactId>api-java</artifactId>
-      <version>0.3.0</version>
+      <version>0.4.0</version>
     </dependency>
     <dependency>
       <groupId>no.cantara.config</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>no.cantara.realestate</groupId>
   <artifactId>azure-client-java</artifactId>
-  <version>0.12.1-SNAPSHOT</version>
+  <version>0.12.2-SNAPSHOT</version>
 
   <name>azure-client-java</name>
   <url>https://github.com/Cantara/realestate-azure-client-lib</url>

--- a/src/main/java/no/cantara/realestate/azure/AzureObservationDistributionClient.java
+++ b/src/main/java/no/cantara/realestate/azure/AzureObservationDistributionClient.java
@@ -129,19 +129,15 @@ public class AzureObservationDistributionClient implements ObservationDistributi
 
     }
 
-    /**
-     * Helper method to re-establish stable connection to Azure IoT
-     */
-    public void pingAzureIotConnection() throws RealEstateException {
-        //FIXME
-    }
 
     /**
      * @param observationMessage the observation to publish
      * @throws RealEstateException if the connection is not established/stable, or the message cannot be built
+     * @throws AzureIotHubConnectionUnstableException if the connection is not established or unstable. Dayly Quota limit reached may also be the cause.
+     * The client should call close on the AzureObservationDistributionClient when receiving this Exception. Then restart the client to re-establish connection to Azure IoT Hub.
      */
     @Override
-    public void publish(ObservationMessage observationMessage) throws RealEstateException {
+    public void publish(ObservationMessage observationMessage) throws RealEstateException, AzureIotHubConnectionUnstableException {
         // Throw a typed exception if the connection is not established, nor stable (#1805).
         verifyStableConnection();
 
@@ -196,7 +192,12 @@ public class AzureObservationDistributionClient implements ObservationDistributi
 
     }
 
-    private void verifyStableConnection() {
+    /**
+     *
+     * @throws RealEstateException if Connection to AzureDeviceClient is not established
+     * @throws AzureIotHubConnectionUnstableException if the connection is not established or unstable
+     */
+    protected void verifyStableConnection() throws RealEstateException {
         if (!isConnectionEstablished()) {
             // Distinguish a genuinely unstable link (network down or quota exhausted) from a
             // not-yet-opened / cleanly-closed client. On instability we stop sending and raise a
@@ -502,14 +503,15 @@ public class AzureObservationDistributionClient implements ObservationDistributi
 
     /**
      * Reject a new send because the MQTT link is unstable (#1805): count the rejection and build the
-     * typed {@link IotHubConnectionUnstableException} the caller throws, so an administrator can be
+     * typed {@link AzureIotHubConnectionUnstableException} the caller throws, so an administrator can be
      * alerted that the network is down or the device quota is exhausted. The message is not buffered
      * — firing it into a dead connection only feeds the reconnect loop we are trying to break.
+     * @throws AzureIotHubConnectionUnstableException Reject a new send because the MQTT link is unstable
      */
-    private IotHubConnectionUnstableException rejectBecauseConnectionUnstable() {
+    private AzureIotHubConnectionUnstableException rejectBecauseConnectionUnstable() throws AzureIotHubConnectionUnstableException {
         addMessagesRejected();
         telemetryClient.trackEvent("error-publish-observationmessage-connection-unstable");
-        IotHubConnectionUnstableException exception = new IotHubConnectionUnstableException(
+        AzureIotHubConnectionUnstableException exception = new AzureIotHubConnectionUnstableException(
                 azureDeviceClient.getConnectionStatus(),
                 azureDeviceClient.getConnectionStatusReason(),
                 azureDeviceClient.getConnectionRetryingForMillis());
@@ -519,12 +521,16 @@ public class AzureObservationDistributionClient implements ObservationDistributi
 
     /**
      * Record a successful send: reset the back-off (#440), close the circuit if it was open (#441),
-     * and restore the bounded retry policy if it had been switched to NoRetry on quota exhaustion.
+     * restore the bounded retry policy if it had been switched to NoRetry on quota exhaustion, and
+     * tell the device client the link is alive so any retry-budget timer is cleared (#1805).
      */
     private void registerSuccess() {
         sendThrottle.recordOutcome(MqttSendFailureType.NONE);
         boolean wasOpen = circuitBreaker.isOpen();
         circuitBreaker.recordOutcome(MqttSendFailureType.NONE, 0);
+        if (azureDeviceClient != null) {
+            azureDeviceClient.notifyMessageDelivered();
+        }
         if (wasOpen && !circuitBreaker.isOpen() && azureDeviceClient != null) {
             azureDeviceClient.useDefaultRetryPolicy();
         }
@@ -553,7 +559,7 @@ public class AzureObservationDistributionClient implements ObservationDistributi
      *     <li>the send circuit is open because IoT Hub is overloaded (#441 — {@code QUOTA_EXCEEDED}
      *     or persistent {@code THROTTLED}); or</li>
      *     <li>the MQTT link is unstable / force-closed to break a reconnect loop (#1805), in which
-     *     case {@code publish} throws {@link IotHubConnectionUnstableException}.</li>
+     *     case {@code publish} throws {@link AzureIotHubConnectionUnstableException}.</li>
      * </ul>
      * Exposed as a single predicate so external callers do not have to know which source stopped
      * sending — the intent is that "someone" can poll this and, when {@code true}, ping/reopen the

--- a/src/main/java/no/cantara/realestate/azure/AzureObservationDistributionClient.java
+++ b/src/main/java/no/cantara/realestate/azure/AzureObservationDistributionClient.java
@@ -35,6 +35,7 @@ import static org.slf4j.LoggerFactory.getLogger;
 @AutoService(ObservationDistributionClient.class)
 public class AzureObservationDistributionClient implements ObservationDistributionClient, DistributionService {
     private static final Logger log = getLogger(AzureObservationDistributionClient.class);
+    private boolean isHealthy;
     private static final int DEFAULT_MAX_SIZE = 1000;
     public static final int MAX_CONSECUTIVE_CLIENT_DISCONNECT_ERRORS = 20;
     public static final String CONNECTIONSTRING_KEY = "distribution.azure.connectionString";
@@ -65,6 +66,8 @@ public class AzureObservationDistributionClient implements ObservationDistributi
     private final Tracer tracer;
     private final TelemetryClient telemetryClient;
     private Instant whenLastMessageDistributedAt = null;
+
+    private String lastUnhealthyCause = null;
 
     /*
     Intended used for testing.
@@ -162,16 +165,18 @@ public class AzureObservationDistributionClient implements ObservationDistributi
                 public void onMessageSent(Message sentMessage, IotHubClientException iotHubClientException, Object callbackContext) {
                     try {
                         if (iotHubClientException != null) {
-                            log.trace("Received Error when sening message to to Azure IoT Hub: {}, Exception: {}", sentMessage, iotHubClientException);
+                            log.trace("Received Error when sending message to to Azure IoT Hub: {}, Exception: {}", sentMessage, iotHubClientException);
                             MqttSendFailureType failureType = registerFailure(iotHubClientException, observationMessage);
                             telemetryClient.trackEvent("publish-failed-" + failureType.name());
                             span.setStatus(StatusCode.ERROR, iotHubClientException.getMessage());
                             span.recordException(iotHubClientException);
+                            setUnhealthy("publish-failed--%s--%s".formatted(messageId, iotHubClientException.getMessage()));
                         } else {
                             log.trace("Message is sent to Azure IoT Hub: {}", sentMessage);
                             addMessagesPublished();
                             registerSuccess();
                             span.setStatus(StatusCode.OK);
+                            setHealthy();
                         }
                         messageSent(sentMessage);
                     } finally {
@@ -226,6 +231,16 @@ public class AzureObservationDistributionClient implements ObservationDistributi
         return true;
     }
 
+    protected void setUnhealthy(String message) {
+        this.lastFailureAt = Instant.now();
+        this.lastUnhealthyCause = message;
+        this.isHealthy = false;
+    }
+
+    protected void setHealthy() {
+        this.isHealthy = true;
+    }
+
     /**
      * Reflects whether sending is operational. Returns {@code false} when either:
      * <ul>
@@ -244,14 +259,14 @@ public class AzureObservationDistributionClient implements ObservationDistributi
     public boolean isHealthy() {
         boolean isConnectionOpen = !circuitBreaker.isOpen();
         int connectionFailures = sendThrottle.getConsecutiveTransientFailures();
-        boolean connectionErrorsBelowTreshold = connectionFailures <= MAX_CONSECUTIVE_CLIENT_DISCONNECT_ERRORS;
+        //TODOboolean connectionErrorsBelowTreshold = connectionFailures <= MAX_CONSECUTIVE_CLIENT_DISCONNECT_ERRORS;
         // The MQTT link being unstable — or force-closed to break a reconnect loop (#1805) — reports
         // unhealthy. This is the signal a reopen-watchdog acts on to bring the connection back.
         boolean linkStable = azureDeviceClient == null || !azureDeviceClient.isConnectionUnstable();
-        boolean isHealthy = isConnectionOpen && connectionErrorsBelowTreshold && linkStable;
-        log.trace("isHealthy: {}. Based on isConectionOpen {}, connectionFailures/maxAlowed {}/{}, linkStable {} ",
-                isHealthy, isConnectionOpen, connectionFailures, MAX_CONSECUTIVE_CLIENT_DISCONNECT_ERRORS, linkStable);
-        return isHealthy;
+        boolean reportHealth = isHealthy && isConnectionOpen && linkStable; //TODO && connectionErrorsBelowTreshold;
+//        log.trace("isHealthy: {}. IsHealthyStatus: {}, isConectionOpen {}, connectionFailures/maxAlowed {}/{}, linkStable {} ",
+//                reportHealth, isHealthy, isConnectionOpen, connectionFailures, MAX_CONSECUTIVE_CLIENT_DISCONNECT_ERRORS, linkStable);
+        return reportHealth;
     }
 
     @Override

--- a/src/main/java/no/cantara/realestate/azure/AzureObservationDistributionClient.java
+++ b/src/main/java/no/cantara/realestate/azure/AzureObservationDistributionClient.java
@@ -131,9 +131,22 @@ public class AzureObservationDistributionClient implements ObservationDistributi
     protected void sendTelemetryMessage() {
 
     }
+
+    /**
+     *
+     * @param observationMessage
+     * @throws RealEstateException
+     *
+     */
     @Override
-    public void publish(ObservationMessage observationMessage) {
+    public void publish(ObservationMessage observationMessage) throws RealEstateException{
         if (!isConnectionEstablished()) {
+            // Distinguish a genuinely unstable link (network down or quota exhausted) from a
+            // not-yet-opened / cleanly-closed client. On instability we stop sending and raise a
+            // typed alarm instead of inviting the distributor to retry into a dead connection.
+            if (azureDeviceClient != null && azureDeviceClient.isConnectionUnstable()) {
+                throw rejectBecauseConnectionUnstable();
+            }
             log.warn("Connection not established, message will be queued/dropped");
             telemetryClient.trackEvent("error-publish-observationmessage-not-connected");
             throw new RealEstateException(
@@ -186,6 +199,7 @@ public class AzureObservationDistributionClient implements ObservationDistributi
                             log.trace("Message is sent to Azure IoT Hub: {}", sentMessage);
                         }
                         Message msg = (Message) callbackContext;
+                        //TODO when needed String originalObservationJson = new String(msg.getBytes(), StandardCharsets.UTF_8);
                         long elapsedTime = System.currentTimeMillis() - startTime;
                         Duration duration = new Duration(elapsedTime);
                         RemoteDependencyTelemetry dependencyTelemetry = new RemoteDependencyTelemetry("IotHub", "SendEventAsync", duration, true);
@@ -262,9 +276,12 @@ public class AzureObservationDistributionClient implements ObservationDistributi
         boolean isConnectionOpen = !circuitBreaker.isOpen();
         int connectionFailures = sendThrottle.getConsecutiveTransientFailures();
         boolean connectionErrorsBelowTreshold = connectionFailures <= MAX_CONSECUTIVE_CLIENT_DISCONNECT_ERRORS;
-        boolean isHealthy = isConnectionOpen && connectionErrorsBelowTreshold;
-        log.trace("isHealthy: {}. Based on isConectionOpen {} and connectionFailures/maxAlowed {}/{} ",
-                isHealthy, isConnectionOpen, connectionFailures, MAX_CONSECUTIVE_CLIENT_DISCONNECT_ERRORS);
+        // The MQTT link being unstable — or force-closed to break a reconnect loop (#1805) — reports
+        // unhealthy. This is the signal a reopen-watchdog acts on to bring the connection back.
+        boolean linkStable = azureDeviceClient == null || !azureDeviceClient.isConnectionUnstable();
+        boolean isHealthy = isConnectionOpen && connectionErrorsBelowTreshold && linkStable;
+        log.trace("isHealthy: {}. Based on isConectionOpen {}, connectionFailures/maxAlowed {}/{}, linkStable {} ",
+                isHealthy, isConnectionOpen, connectionFailures, MAX_CONSECUTIVE_CLIENT_DISCONNECT_ERRORS, linkStable);
         return isHealthy;
     }
 
@@ -417,6 +434,12 @@ public class AzureObservationDistributionClient implements ObservationDistributi
                 log.error("Azure IoT Hub permanent send failure: retrying will not help, message should be dropped. " +
                         "statusCode={}, observationMessage={}", statusCode, observationMessage, exception);
                 break;
+            case UNDELIVERABLE:
+                log.error("Azure IoT Hub message UNDELIVERABLE: the message was dropped without delivery " +
+                        "(connection closed/expired before ack). When sending is already stopped this confirms the " +
+                        "network is down or the device quota is exhausted — alert an administrator. " +
+                        "statusCode={}, observationMessage={}", statusCode, observationMessage, exception);
+                break;
             case TRANSIENT:
                 log.warn("Azure IoT Hub transient send failure: safe to retry after a delay. " +
                         "statusCode={}, observationMessage={}", statusCode, observationMessage, exception);
@@ -512,6 +535,23 @@ public class AzureObservationDistributionClient implements ObservationDistributi
         telemetryClient.trackEvent("error-publish-observationmessage-circuit-open");
         log.debug("MQTT send circuit OPEN (reason={}); rejecting observationMessage. Rejected total={}",
                 circuitBreaker.getOpenReason(), numberOfMessagesRejected);
+    }
+
+    /**
+     * Reject a new send because the MQTT link is unstable (#1805): count the rejection and build the
+     * typed {@link IotHubConnectionUnstableException} the caller throws, so an administrator can be
+     * alerted that the network is down or the device quota is exhausted. The message is not buffered
+     * — firing it into a dead connection only feeds the reconnect loop we are trying to break.
+     */
+    private IotHubConnectionUnstableException rejectBecauseConnectionUnstable() {
+        addMessagesRejected();
+        telemetryClient.trackEvent("error-publish-observationmessage-connection-unstable");
+        IotHubConnectionUnstableException exception = new IotHubConnectionUnstableException(
+                azureDeviceClient.getConnectionStatus(),
+                azureDeviceClient.getConnectionStatusReason(),
+                azureDeviceClient.getConnectionRetryingForMillis());
+        log.error("Rejecting publish — {} Rejected total={}", exception.getMessage(), numberOfMessagesRejected);
+        return exception;
     }
 
     /**

--- a/src/main/java/no/cantara/realestate/azure/AzureObservationDistributionClient.java
+++ b/src/main/java/no/cantara/realestate/azure/AzureObservationDistributionClient.java
@@ -14,6 +14,7 @@ import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.api.trace.StatusCode;
 import io.opentelemetry.api.trace.Tracer;
 import no.cantara.realestate.ExceptionStatusType;
+import no.cantara.realestate.MqttUnavailableException;
 import no.cantara.realestate.RealEstateException;
 import no.cantara.realestate.azure.iot.*;
 import no.cantara.realestate.azure.rec.RecObservationMessage;
@@ -130,14 +131,9 @@ public class AzureObservationDistributionClient implements ObservationDistributi
     }
 
 
-    /**
-     * @param observationMessage the observation to publish
-     * @throws RealEstateException if the connection is not established/stable, or the message cannot be built
-     * @throws AzureIotHubConnectionUnstableException if the connection is not established or unstable. Dayly Quota limit reached may also be the cause.
-     * The client should call close on the AzureObservationDistributionClient when receiving this Exception. Then restart the client to re-establish connection to Azure IoT Hub.
-     */
+
     @Override
-    public void publish(ObservationMessage observationMessage) throws RealEstateException, AzureIotHubConnectionUnstableException {
+    public void publish(ObservationMessage observationMessage) throws RealEstateException, MqttUnavailableException {
         // Throw a typed exception if the connection is not established, nor stable (#1805).
         verifyStableConnection();
 
@@ -195,22 +191,33 @@ public class AzureObservationDistributionClient implements ObservationDistributi
     /**
      *
      * @throws RealEstateException if Connection to AzureDeviceClient is not established
-     * @throws AzureIotHubConnectionUnstableException if the connection is not established or unstable
+     * @throws MqttUnavailableException if the connection is not established or unstable
      */
     protected void verifyStableConnection() throws RealEstateException {
+        if (azureDeviceClient == null) {
+            throw new RealEstateException("Azure device client is not initialized", ExceptionStatusType.RETRY_NOT_POSSIBLE);
+        }
         if (!isConnectionEstablished()) {
             // Distinguish a genuinely unstable link (network down or quota exhausted) from a
             // not-yet-opened / cleanly-closed client. On instability we stop sending and raise a
             // typed alarm instead of inviting the distributor to retry into a dead connection.
-            if (azureDeviceClient != null && azureDeviceClient.isConnectionUnstable()) {
-                throw rejectBecauseConnectionUnstable();
+            if ( azureDeviceClient.isConnectionUnstable()) {
+                addMessagesRejected();
+                telemetryClient.trackEvent("error-publish-observationmessage-connection-unstable");
+                AzureIotHubConnectionUnstableException exception = new AzureIotHubConnectionUnstableException(
+                        azureDeviceClient.getConnectionStatus(),
+                        azureDeviceClient.getConnectionStatusReason(),
+                        azureDeviceClient.getConnectionRetryingForMillis());
+                log.error("Rejecting publish — {} Rejected total={}", exception.getMessage(), numberOfMessagesRejected);
+                throw new MqttUnavailableException("Connection to AzureDeviceClient is unstable. Client should call closeConnection(), wait and re-connect: " + exception.getMessage(), exception, ExceptionStatusType.RETRY_NOT_POSSIBLE);
+            } else {
+                log.warn("Connection not established, message will be queued/dropped");
+                telemetryClient.trackEvent("publish-not-connected");
+                throw new RealEstateException(
+                        "Connection to AzureDeviceClient is not established",
+                        ExceptionStatusType.RETRY_MAY_FIX_ISSUE  // ✅ RETRY_POSSIBLE i stedet!
+                );
             }
-            log.warn("Connection not established, message will be queued/dropped");
-            telemetryClient.trackEvent("publish-not-connected");
-            throw new RealEstateException(
-                    "Connection to AzureDeviceClient is not established",
-                    ExceptionStatusType.RETRY_MAY_FIX_ISSUE  // ✅ RETRY_POSSIBLE i stedet!
-            );
         }
     }
 

--- a/src/main/java/no/cantara/realestate/azure/AzureObservationDistributionClient.java
+++ b/src/main/java/no/cantara/realestate/azure/AzureObservationDistributionClient.java
@@ -133,6 +133,13 @@ public class AzureObservationDistributionClient implements ObservationDistributi
     }
 
     /**
+     * Helper method to re-establish stable connection to Azure IoT
+     */
+    public void pingAzureIotConnection() throws RealEstateException {
+        //FIXME
+    }
+
+    /**
      *
      * @param observationMessage
      * @throws RealEstateException
@@ -140,20 +147,8 @@ public class AzureObservationDistributionClient implements ObservationDistributi
      */
     @Override
     public void publish(ObservationMessage observationMessage) throws RealEstateException{
-        if (!isConnectionEstablished()) {
-            // Distinguish a genuinely unstable link (network down or quota exhausted) from a
-            // not-yet-opened / cleanly-closed client. On instability we stop sending and raise a
-            // typed alarm instead of inviting the distributor to retry into a dead connection.
-            if (azureDeviceClient != null && azureDeviceClient.isConnectionUnstable()) {
-                throw rejectBecauseConnectionUnstable();
-            }
-            log.warn("Connection not established, message will be queued/dropped");
-            telemetryClient.trackEvent("error-publish-observationmessage-not-connected");
-            throw new RealEstateException(
-                    "Connection to AzureDeviceClient is not established",
-                    ExceptionStatusType.RETRY_MAY_FIX_ISSUE  // ✅ RETRY_POSSIBLE i stedet!
-            );
-        }
+        //Throw Exception if connection is not established, nor is sable.
+        verifyStableConnection();
         long startTime = System.currentTimeMillis();
 //        log.info("Tracer: {}", tracer);
         Span parentSpan = tracer.spanBuilder("IotHub").startSpan();
@@ -250,6 +245,23 @@ public class AzureObservationDistributionClient implements ObservationDistributi
             parentSpan.end();
         }
 
+    }
+
+    private void verifyStableConnection() {
+        if (!isConnectionEstablished()) {
+            // Distinguish a genuinely unstable link (network down or quota exhausted) from a
+            // not-yet-opened / cleanly-closed client. On instability we stop sending and raise a
+            // typed alarm instead of inviting the distributor to retry into a dead connection.
+            if (azureDeviceClient != null && azureDeviceClient.isConnectionUnstable()) {
+                throw rejectBecauseConnectionUnstable();
+            }
+            log.warn("Connection not established, message will be queued/dropped");
+            telemetryClient.trackEvent("error-publish-observationmessage-not-connected");
+            throw new RealEstateException(
+                    "Connection to AzureDeviceClient is not established",
+                    ExceptionStatusType.RETRY_MAY_FIX_ISSUE  // ✅ RETRY_POSSIBLE i stedet!
+            );
+        }
     }
 
     @Override

--- a/src/main/java/no/cantara/realestate/azure/AzureObservationDistributionClient.java
+++ b/src/main/java/no/cantara/realestate/azure/AzureObservationDistributionClient.java
@@ -71,7 +71,7 @@ public class AzureObservationDistributionClient implements ObservationDistributi
     /*
     Intended used for testing.
      */
-    public AzureObservationDistributionClient(AzureDeviceClient azureDeviceClient) {
+    protected AzureObservationDistributionClient(AzureDeviceClient azureDeviceClient) {
         tracer = GlobalOpenTelemetry.getTracer("OTEL.AzureMonitor.AzureObservationDistributionClient");
         telemetryClient = new TelemetryClient();
         this.azureDeviceClient = azureDeviceClient;
@@ -81,7 +81,7 @@ public class AzureObservationDistributionClient implements ObservationDistributi
     /*
     Intended used for test client
      */
-    public AzureObservationDistributionClient(AzureDeviceClient azureDeviceClient, String connectionString) {
+    protected AzureObservationDistributionClient(AzureDeviceClient azureDeviceClient, String connectionString) {
         tracer = GlobalOpenTelemetry.getTracer("OTEL.AzureMonitor.AzureObservationDistributionClient");
         telemetryClient = new TelemetryClient();
         this.azureDeviceClient = azureDeviceClient != null ? azureDeviceClient : new AzureDeviceClient(connectionString);

--- a/src/main/java/no/cantara/realestate/azure/AzureObservationDistributionClient.java
+++ b/src/main/java/no/cantara/realestate/azure/AzureObservationDistributionClient.java
@@ -547,16 +547,29 @@ public class AzureObservationDistributionClient implements ObservationDistributi
     }
 
     /**
-     * @return {@code true} if new sends are currently being rejected because IoT Hub is overloaded
-     * (the send circuit is open). Mirrors {@code !isHealthy()}.
+     * @return {@code true} if {@link #publish(ObservationMessage)} is currently rejecting new sends.
+     * This is the case when either source has stopped sending:
+     * <ul>
+     *     <li>the send circuit is open because IoT Hub is overloaded (#441 — {@code QUOTA_EXCEEDED}
+     *     or persistent {@code THROTTLED}); or</li>
+     *     <li>the MQTT link is unstable / force-closed to break a reconnect loop (#1805), in which
+     *     case {@code publish} throws {@link IotHubConnectionUnstableException}.</li>
+     * </ul>
+     * Exposed as a single predicate so external callers do not have to know which source stopped
+     * sending — the intent is that "someone" can poll this and, when {@code true}, ping/reopen the
+     * connection to recover. Today the circuit-breaker source is the only one that reopens on its own.
      */
     public boolean isSendingStopped() {
-        return circuitBreaker.isOpen();
+        boolean linkUnstable = azureDeviceClient != null && azureDeviceClient.isConnectionUnstable();
+        return circuitBreaker.isOpen() || linkUnstable;
     }
 
     /**
-     * @return the failure category that stopped sending ({@code QUOTA_EXCEEDED} or {@code THROTTLED}),
-     * or {@code null} if sending is not stopped.
+     * @return the IoT Hub overload category that opened the send circuit ({@code QUOTA_EXCEEDED} or
+     * {@code THROTTLED}), or {@code null} when sending is not stopped by the circuit. Note that a
+     * stop caused by an <em>unstable link</em> (#1805) has no {@link MqttSendFailureType} — the cause
+     * cannot be determined from the client side — so this returns {@code null} even though
+     * {@link #isSendingStopped()} is {@code true}; inspect the link status for that case.
      */
     public MqttSendFailureType getSendStoppedReason() {
         return circuitBreaker.getOpenReason();

--- a/src/main/java/no/cantara/realestate/azure/iot/AzureDeviceClient.java
+++ b/src/main/java/no/cantara/realestate/azure/iot/AzureDeviceClient.java
@@ -6,11 +6,6 @@ import com.microsoft.azure.sdk.iot.device.transport.ExponentialBackoffWithJitter
 import com.microsoft.azure.sdk.iot.device.transport.IotHubConnectionStatus;
 import com.microsoft.azure.sdk.iot.device.transport.NoRetry;
 import com.microsoft.azure.sdk.iot.device.transport.RetryPolicy;
-
-import java.util.concurrent.Executors;
-import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicBoolean;
 import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.SpanKind;
@@ -18,6 +13,8 @@ import io.opentelemetry.api.trace.StatusCode;
 import io.opentelemetry.api.trace.Tracer;
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
 import org.slf4j.Logger;
+
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import static no.cantara.realestate.azure.metrics.MetricsConfig.INSTRUMENTATION_SCOPE_NAME;
 import static org.slf4j.LoggerFactory.getLogger;
@@ -40,10 +37,6 @@ public class AzureDeviceClient {
     // Tracks the real MQTT link state from the SDK's connection-status callback and decides when a
     // silent reconnect loop must be broken by force-closing the client (azure-iot-sdk-java#1805).
     private final IotHubConnectionMonitor connectionMonitor;
-    // Re-evaluates the force-close decision on a timer. The SDK fires the status callback only once
-    // when it enters DISCONNECTED_RETRYING and then retries silently — so the retry-budget trigger
-    // would never be re-checked from the callback alone. This poller is what makes it fire.
-    private final ScheduledExecutorService instabilityWatchdog;
     // Guards the force-close so it runs at most once per instability episode.
     private final AtomicBoolean closing = new AtomicBoolean(false);
 
@@ -60,7 +53,6 @@ public class AzureDeviceClient {
         this.connectionMonitor = new IotHubConnectionMonitor();
         applyBoundedRetryPolicy();
         registerConnectionStatusCallback();
-        this.instabilityWatchdog = startInstabilityWatchdog();
         tracer = GlobalOpenTelemetry.getTracer(INSTRUMENTATION_SCOPE_NAME);
     }
 
@@ -82,31 +74,15 @@ public class AzureDeviceClient {
         this.connectionMonitor = connectionMonitor;
         applyBoundedRetryPolicy();
         registerConnectionStatusCallback();
-        this.instabilityWatchdog = startInstabilityWatchdog();
         tracer = GlobalOpenTelemetry.getTracer(INSTRUMENTATION_SCOPE_NAME);
     }
 
     /**
-     * Start the timer that re-evaluates the force-close decision while the link is stuck retrying.
-     * Polls at a quarter of the retry budget (the SDK won't re-notify us during a silent reconnect
-     * loop, so we have to check the clock ourselves). The thread is a daemon and a no-op whenever the
-     * link is healthy.
-     */
-    private ScheduledExecutorService startInstabilityWatchdog() {
-        long pollMillis = Math.max(50L, connectionMonitor.getMaxRetryingMillis() / 4);
-        ScheduledExecutorService executor = Executors.newSingleThreadScheduledExecutor(runnable -> {
-            Thread thread = new Thread(runnable, "iothub-instability-watchdog");
-            thread.setDaemon(true);
-            return thread;
-        });
-        executor.scheduleWithFixedDelay(this::evaluateForceClose, pollMillis, pollMillis, TimeUnit.MILLISECONDS);
-        return executor;
-    }
-
-    /**
-     * Re-check whether the reconnect loop should be broken, and force-close if so. Called both from
-     * the status callback (immediate, for {@code RETRY_EXPIRED}) and periodically from the watchdog
-     * (for the retry-budget case the callback never re-evaluates). Package-private for testing.
+     * Re-check whether the reconnect loop should be broken, and force-close if so. Driven entirely by
+     * the SDK's connection-status callback: the SDK re-fires {@code DISCONNECTED_RETRYING} on each
+     * reconnect attempt, and the monitor measures elapsed time from the first one — so by the time a
+     * later attempt arrives past the retry budget, this closes the client. {@code RETRY_EXPIRED}
+     * (the SDK giving up) triggers it immediately. Package-private for testing.
      */
     void evaluateForceClose() {
         try {
@@ -114,7 +90,7 @@ public class AzureDeviceClient {
                 forceCloseDueToInstability();
             }
         } catch (Exception e) {
-            log.error("IoT Hub instability watchdog evaluation failed", e);
+            log.error("IoT Hub force-close evaluation failed", e);
         }
     }
 
@@ -156,8 +132,9 @@ public class AzureDeviceClient {
                         newCause == null ? "none" : newCause.toString());
             }
         }
-        // Immediate path: RETRY_EXPIRED (SDK gave up) is a status transition, so it fires here. The
-        // retry-budget case has no further transition and is caught by the watchdog poll instead.
+        // Re-evaluate on every status change. RETRY_EXPIRED closes immediately; for a persistent
+        // DISCONNECTED_RETRYING the SDK re-fires this callback on each reconnect attempt, and the
+        // monitor closes once the elapsed time from the first attempt passes the retry budget.
         evaluateForceClose();
     }
 
@@ -316,6 +293,15 @@ public class AzureDeviceClient {
     /** @return how long the link has been retrying to reconnect, in ms, or {@code 0} if not retrying. */
     public long getConnectionRetryingForMillis() {
         return connectionMonitor.getRetryingForMillis();
+    }
+
+    /**
+     * Notify the monitor that a message was delivered successfully. Proves the link is alive, so it
+     * clears the retry clock — the same effect as a {@code CONNECTED} event — and prevents a stale
+     * retrying window from accumulating toward a force-close.
+     */
+    public void notifyMessageDelivered() {
+        connectionMonitor.recordSuccessfulSend();
     }
 
     public static void main(String[] args) {

--- a/src/main/java/no/cantara/realestate/azure/iot/AzureDeviceClient.java
+++ b/src/main/java/no/cantara/realestate/azure/iot/AzureDeviceClient.java
@@ -3,8 +3,14 @@ package no.cantara.realestate.azure.iot;
 import com.microsoft.azure.sdk.iot.device.*;
 import com.microsoft.azure.sdk.iot.device.exceptions.IotHubClientException;
 import com.microsoft.azure.sdk.iot.device.transport.ExponentialBackoffWithJitter;
+import com.microsoft.azure.sdk.iot.device.transport.IotHubConnectionStatus;
 import com.microsoft.azure.sdk.iot.device.transport.NoRetry;
 import com.microsoft.azure.sdk.iot.device.transport.RetryPolicy;
+
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.SpanKind;
@@ -31,7 +37,17 @@ public class AzureDeviceClient {
     private final DeviceClient deviceClient;
     private final Tracer tracer;
 
-    private boolean connectionEstablished = false;
+    // Tracks the real MQTT link state from the SDK's connection-status callback and decides when a
+    // silent reconnect loop must be broken by force-closing the client (azure-iot-sdk-java#1805).
+    private final IotHubConnectionMonitor connectionMonitor;
+    // Re-evaluates the force-close decision on a timer. The SDK fires the status callback only once
+    // when it enters DISCONNECTED_RETRYING and then retries silently — so the retry-budget trigger
+    // would never be re-checked from the callback alone. This poller is what makes it fire.
+    private final ScheduledExecutorService instabilityWatchdog;
+    // Guards the force-close so it runs at most once per instability episode.
+    private final AtomicBoolean closing = new AtomicBoolean(false);
+
+    private volatile boolean connectionEstablished = false;
     private boolean retryConnection;
     private String iotHubHostname = "";
 
@@ -41,7 +57,10 @@ public class AzureDeviceClient {
         if (deviceClient != null && deviceClient.getConfig() != null) {
             iotHubHostname = deviceClient.getConfig().getIotHubHostname();
         }
+        this.connectionMonitor = new IotHubConnectionMonitor();
         applyBoundedRetryPolicy();
+        registerConnectionStatusCallback();
+        this.instabilityWatchdog = startInstabilityWatchdog();
         tracer = GlobalOpenTelemetry.getTracer(INSTRUMENTATION_SCOPE_NAME);
     }
 
@@ -49,12 +68,122 @@ public class AzureDeviceClient {
         Intended for testing
          */
     protected AzureDeviceClient(DeviceClient deviceClient) {
+        this(deviceClient, new IotHubConnectionMonitor());
+    }
+
+    /*
+        Intended for testing — inject a connection monitor with a deterministic clock / short budget.
+         */
+    AzureDeviceClient(DeviceClient deviceClient, IotHubConnectionMonitor connectionMonitor) {
         this.deviceClient = deviceClient;
         if (deviceClient != null && deviceClient.getConfig() != null) {
             iotHubHostname = deviceClient.getConfig().getIotHubHostname();
         }
+        this.connectionMonitor = connectionMonitor;
         applyBoundedRetryPolicy();
+        registerConnectionStatusCallback();
+        this.instabilityWatchdog = startInstabilityWatchdog();
         tracer = GlobalOpenTelemetry.getTracer(INSTRUMENTATION_SCOPE_NAME);
+    }
+
+    /**
+     * Start the timer that re-evaluates the force-close decision while the link is stuck retrying.
+     * Polls at a quarter of the retry budget (the SDK won't re-notify us during a silent reconnect
+     * loop, so we have to check the clock ourselves). The thread is a daemon and a no-op whenever the
+     * link is healthy.
+     */
+    private ScheduledExecutorService startInstabilityWatchdog() {
+        long pollMillis = Math.max(50L, connectionMonitor.getMaxRetryingMillis() / 4);
+        ScheduledExecutorService executor = Executors.newSingleThreadScheduledExecutor(runnable -> {
+            Thread thread = new Thread(runnable, "iothub-instability-watchdog");
+            thread.setDaemon(true);
+            return thread;
+        });
+        executor.scheduleWithFixedDelay(this::evaluateForceClose, pollMillis, pollMillis, TimeUnit.MILLISECONDS);
+        return executor;
+    }
+
+    /**
+     * Re-check whether the reconnect loop should be broken, and force-close if so. Called both from
+     * the status callback (immediate, for {@code RETRY_EXPIRED}) and periodically from the watchdog
+     * (for the retry-budget case the callback never re-evaluates). Package-private for testing.
+     */
+    void evaluateForceClose() {
+        try {
+            if (connectionMonitor.shouldForceClose()) {
+                forceCloseDueToInstability();
+            }
+        } catch (Exception e) {
+            log.error("IoT Hub instability watchdog evaluation failed", e);
+        }
+    }
+
+    /**
+     * Subscribe to the SDK's connection-status changes. This is the only channel that surfaces a
+     * dropped MQTT link and the SDK's internal reconnect attempts — the per-message send callback
+     * never sees them (azure-iot-sdk-java#1805).
+     */
+    private void registerConnectionStatusCallback() {
+        if (deviceClient == null) {
+            return;
+        }
+        deviceClient.setConnectionStatusChangeCallback(
+                context -> handleConnectionStatusChange(
+                        context.getNewStatus(), context.getNewStatusReason(), context.getCause()),
+                null);
+    }
+
+    /**
+     * Handle one connection-status transition: update the link state, mirror it onto
+     * {@link #connectionEstablished}, and force-close the client if the monitor decides the reconnect
+     * loop is no longer expected to recover.
+     *
+     * <p>Package-private so the decision wiring can be driven from a unit test without a live SDK.
+     */
+    void handleConnectionStatusChange(IotHubConnectionStatus newStatus,
+                                      com.microsoft.azure.sdk.iot.device.IotHubConnectionStatusChangeReason newReason,
+                                      Throwable newCause) {
+        connectionMonitor.recordStatusChange(newStatus, newReason, newCause);
+        connectionEstablished = newStatus == IotHubConnectionStatus.CONNECTED;
+        if (newStatus == IotHubConnectionStatus.CONNECTED) {
+            log.info("IoT Hub connection status: CONNECTED (reason={})", newReason);
+        } else {
+            if (newStatus == IotHubConnectionStatus.DISCONNECTED_RETRYING) {
+                log.debug("IoT Hub connection status: {} (reason={}, cause={})", newStatus, newReason,
+                        newCause == null ? "none" : newCause.toString());
+            } else {
+                log.warn("IoT Hub connection status: {} (reason={}, cause={})", newStatus, newReason,
+                        newCause == null ? "none" : newCause.toString());
+            }
+        }
+        // Immediate path: RETRY_EXPIRED (SDK gave up) is a status transition, so it fires here. The
+        // retry-budget case has no further transition and is caught by the watchdog poll instead.
+        evaluateForceClose();
+    }
+
+    /**
+     * Force-close the client to stop the SDK's reconnect threads. The SDK will not stop them on its
+     * own; {@code close()} is the only lever. It must run off the callback thread — {@code close()}
+     * joins on the very SDK threads that invoke the status callback, so calling it inline deadlocks.
+     */
+    private void forceCloseDueToInstability() {
+        if (!closing.compareAndSet(false, true)) {
+            return;
+        }
+        connectionMonitor.markClosedDueToInstability();
+        Thread closer = new Thread(() -> {
+            try {
+                log.warn("Force-closing IoT Hub client to break the reconnect loop (status={}, reason={}).",
+                        connectionMonitor.getStatus(), connectionMonitor.getReason());
+                closeConnection();
+            } catch (Exception e) {
+                log.error("Failed to force-close IoT Hub client after detected instability", e);
+            } finally {
+                closing.set(false);
+            }
+        }, "iothub-instability-closer");
+        closer.setDaemon(true);
+        closer.start();
     }
 
     /**
@@ -163,6 +292,30 @@ public class AzureDeviceClient {
 
     public boolean isConnectionEstablished() {
         return connectionEstablished;
+    }
+
+    /**
+     * @return {@code true} when sending should be treated as stopped because the MQTT link is
+     * unstable (retrying / disconnected with an error) or the client has been force-closed to break
+     * a reconnect loop. A clean, intended close is not reported as unstable.
+     */
+    public boolean isConnectionUnstable() {
+        return connectionMonitor.isConnectionUnstableOrStopped();
+    }
+
+    /** @return the last connection status reported by the SDK. */
+    public IotHubConnectionStatus getConnectionStatus() {
+        return connectionMonitor.getStatus();
+    }
+
+    /** @return the reason behind the last connection-status change, or {@code null} if none yet. */
+    public com.microsoft.azure.sdk.iot.device.IotHubConnectionStatusChangeReason getConnectionStatusReason() {
+        return connectionMonitor.getReason();
+    }
+
+    /** @return how long the link has been retrying to reconnect, in ms, or {@code 0} if not retrying. */
+    public long getConnectionRetryingForMillis() {
+        return connectionMonitor.getRetryingForMillis();
     }
 
     public static void main(String[] args) {

--- a/src/main/java/no/cantara/realestate/azure/iot/AzureIotHubConnectionUnstableException.java
+++ b/src/main/java/no/cantara/realestate/azure/iot/AzureIotHubConnectionUnstableException.java
@@ -25,21 +25,21 @@ import no.cantara.realestate.RealEstateException;
  * <pre>{@code
  * try {
  *     distributionClient.publish(observation);
- * } catch (IotHubConnectionUnstableException e) {
+ * } catch (AzureIotHubConnectionUnstableException e) {
  *     alerting.raise("IoT Hub link unstable: " + e.getMessage(),
  *                    e.getConnectionStatus(), e.getReason());
  * }
  * }</pre>
  */
-public class IotHubConnectionUnstableException extends RealEstateException {
+public class AzureIotHubConnectionUnstableException extends RealEstateException {
 
     private final IotHubConnectionStatus connectionStatus;
     private final IotHubConnectionStatusChangeReason reason;
     private final long retryingForMillis;
 
-    public IotHubConnectionUnstableException(IotHubConnectionStatus connectionStatus,
-                                             IotHubConnectionStatusChangeReason reason,
-                                             long retryingForMillis) {
+    public AzureIotHubConnectionUnstableException(IotHubConnectionStatus connectionStatus,
+                                                  IotHubConnectionStatusChangeReason reason,
+                                                  long retryingForMillis) {
         super(buildMessage(connectionStatus, reason, retryingForMillis), ExceptionStatusType.connection_error);
         this.connectionStatus = connectionStatus;
         this.reason = reason;

--- a/src/main/java/no/cantara/realestate/azure/iot/IotHubConnectionMonitor.java
+++ b/src/main/java/no/cantara/realestate/azure/iot/IotHubConnectionMonitor.java
@@ -132,6 +132,18 @@ public class IotHubConnectionMonitor {
     }
 
     /**
+     * Record observed link activity — a successfully delivered message. Like a {@code CONNECTED}
+     * event, this proves the link is alive, so the retry clock is cleared and the accumulated
+     * retrying time no longer counts toward a force-close. Has no effect once the client has been
+     * force-closed (no sends can succeed then).
+     */
+    public synchronized void recordSuccessfulSend() {
+        if (!closedDueToInstability) {
+            retryingSinceMillis = 0L;
+        }
+    }
+
+    /**
      * Mark that the client has been (or is being) force-closed because of link instability. Keeps
      * {@link #shouldForceClose()} from firing again and keeps the link reported as not-healthy until
      * a successful reconnect produces a {@code CONNECTED} event.

--- a/src/main/java/no/cantara/realestate/azure/iot/IotHubConnectionMonitor.java
+++ b/src/main/java/no/cantara/realestate/azure/iot/IotHubConnectionMonitor.java
@@ -1,0 +1,204 @@
+package no.cantara.realestate.azure.iot;
+
+import com.microsoft.azure.sdk.iot.device.IotHubConnectionStatusChangeReason;
+import com.microsoft.azure.sdk.iot.device.transport.IotHubConnectionStatus;
+import org.slf4j.Logger;
+
+import java.util.function.LongSupplier;
+
+import static org.slf4j.LoggerFactory.getLogger;
+
+/**
+ * Tracks the Azure IoT Hub link state from the SDK's connection-status callback and decides when the
+ * client should be force-closed to break a silent reconnect loop.
+ *
+ * <p>Background: when the device message quota is exhausted (or the network drops), IoT Hub closes
+ * the MQTT connection and the SDK retries internally on its own threads. Those retries are invisible
+ * to the per-message {@code MessageSentCallback}; the failure "just spins" inside the SDK
+ * (see <a href="https://github.com/Azure/azure-iot-sdk-java/issues/1805">azure-iot-sdk-java#1805</a>).
+ * The connection-status callback is the only channel that surfaces it, and the SDK will not stop the
+ * retry threads on its own — the application has to call {@code close()}.
+ *
+ * <p>This monitor is the decision logic behind that. It is deliberately a small, clock-injectable
+ * unit (mirroring {@link MqttSendThrottle} / {@link MqttSendCircuitBreaker}) so the timing rules can
+ * be unit-tested without a live SDK. The wiring — registering the callback and actually running
+ * {@code close()} on a separate thread — lives in {@link AzureDeviceClient}.
+ *
+ * <p>A network blip is tolerated: {@code DISCONNECTED_RETRYING} alone does not force a close. The
+ * client is closed only when recovery is no longer plausible:
+ * <ul>
+ *     <li>the SDK itself gave up — {@code DISCONNECTED} with reason {@code RETRY_EXPIRED}; or</li>
+ *     <li>the link has been stuck in {@code DISCONNECTED_RETRYING} longer than
+ *     {@link #DEFAULT_MAX_RETRYING_MILLIS} (a safety net in case the SDK keeps retrying — the
+ *     intended reconnect window is ~4 minutes, see
+ *     <a href="https://github.com/Azure/azure-iot-sdk-java/issues/377">azure-iot-sdk-java#377</a>).</li>
+ * </ul>
+ *
+ * <p>Thread-safety: status changes arrive on an SDK callback thread while link-state is read from
+ * the distributor thread, so all access is {@code synchronized}.
+ */
+public class IotHubConnectionMonitor {
+    private static final Logger log = getLogger(IotHubConnectionMonitor.class);
+
+    /**
+     * Safety net for the "SDK keeps retrying forever" case. Set above the SDK's intended ~4-minute
+     * reconnect window (#377) so the SDK's own {@code RETRY_EXPIRED} is the normal trigger and this
+     * only fires if that never comes.
+     */
+    public static final long DEFAULT_MAX_RETRYING_MILLIS = 60_000L; // 1 min
+
+    private final long maxRetryingMillis;
+    private final LongSupplier clockMillis;
+
+    private IotHubConnectionStatus status = IotHubConnectionStatus.DISCONNECTED;
+    private IotHubConnectionStatusChangeReason reason = null;
+    private Throwable cause = null;
+    private long retryingSinceMillis = 0L;
+    private boolean closedDueToInstability = false;
+
+    public IotHubConnectionMonitor() {
+        this(DEFAULT_MAX_RETRYING_MILLIS, System::currentTimeMillis);
+    }
+
+    public IotHubConnectionMonitor(long maxRetryingMillis) {
+        this(maxRetryingMillis, System::currentTimeMillis);
+    }
+
+    // Visible for testing — inject a deterministic clock.
+    IotHubConnectionMonitor(long maxRetryingMillis, LongSupplier clockMillis) {
+        this.maxRetryingMillis = maxRetryingMillis;
+        this.clockMillis = clockMillis;
+    }
+
+    /**
+     * Record a connection-status transition reported by the SDK.
+     *
+     * @param newStatus the new link status (ignored if {@code null})
+     * @param newReason why the SDK changed to this status
+     * @param newCause  the underlying throwable, if any
+     */
+    public synchronized void recordStatusChange(IotHubConnectionStatus newStatus,
+                                                IotHubConnectionStatusChangeReason newReason,
+                                                Throwable newCause) {
+        if (newStatus == null) {
+            return;
+        }
+        this.status = newStatus;
+        this.reason = newReason;
+        this.cause = newCause;
+        switch (newStatus) {
+            case CONNECTED:
+                // Recovered: clear the retry clock and any prior force-close state.
+                retryingSinceMillis = 0L;
+                closedDueToInstability = false;
+                break;
+            case DISCONNECTED_RETRYING:
+                if (retryingSinceMillis == 0L) {
+                    retryingSinceMillis = clockMillis.getAsLong();
+                }
+                break;
+            case DISCONNECTED:
+                // Keep retryingSinceMillis for diagnostics; the reason tells us whether this is a
+                // clean close (CLIENT_CLOSE) or the SDK giving up (RETRY_EXPIRED, NO_NETWORK, ...).
+                break;
+            default:
+                // No other statuses exist today; ignore defensively.
+        }
+    }
+
+    /**
+     * @return {@code true} when the client should be force-closed to stop a reconnect loop that is
+     * no longer expected to recover (SDK gave up, or stuck retrying past the safety-net budget).
+     * Returns {@code false} once {@link #markClosedDueToInstability()} has been called, so the close
+     * is triggered only once.
+     */
+    public synchronized boolean shouldForceClose() {
+        if (closedDueToInstability) {
+            return false;
+        }
+        if (status == IotHubConnectionStatus.DISCONNECTED
+                && reason == IotHubConnectionStatusChangeReason.RETRY_EXPIRED) {
+            return true;
+        }
+        if (status == IotHubConnectionStatus.DISCONNECTED_RETRYING && retryingSinceMillis > 0L) {
+            long retryingFor = clockMillis.getAsLong() - retryingSinceMillis;
+            if (retryingFor >= maxRetryingMillis) {
+                log.warn("IoT Hub stuck in DISCONNECTED_RETRYING for {} ms (>= {} ms budget); " +
+                        "the SDK is not giving up on its own — forcing a close.", retryingFor, maxRetryingMillis);
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Mark that the client has been (or is being) force-closed because of link instability. Keeps
+     * {@link #shouldForceClose()} from firing again and keeps the link reported as not-healthy until
+     * a successful reconnect produces a {@code CONNECTED} event.
+     */
+    public synchronized void markClosedDueToInstability() {
+        closedDueToInstability = true;
+    }
+
+    /**
+     * @return {@code true} while the link is down in a way that is not a clean, intended close —
+     * i.e. retrying, or disconnected with an error reason. A fresh (never-opened) monitor and a
+     * deliberate {@code CLIENT_CLOSE} are <em>not</em> reported as unstable.
+     */
+    public synchronized boolean isLinkUnstable() {
+        if (status == IotHubConnectionStatus.DISCONNECTED_RETRYING) {
+            return true;
+        }
+        if (status == IotHubConnectionStatus.DISCONNECTED) {
+            return reason != null
+                    && reason != IotHubConnectionStatusChangeReason.CLIENT_CLOSE
+                    && reason != IotHubConnectionStatusChangeReason.CONNECTION_OK;
+        }
+        return false;
+    }
+
+    /**
+     * @return {@code true} if sending should be treated as stopped because the link is unstable or
+     * the client has been force-closed by this monitor. This is the predicate the distributor uses
+     * to reject new sends and report unhealthy.
+     */
+    public synchronized boolean isConnectionUnstableOrStopped() {
+        return closedDueToInstability || isLinkUnstable();
+    }
+
+    public synchronized boolean isClosedDueToInstability() {
+        return closedDueToInstability;
+    }
+
+    /**
+     * @return the retry budget in milliseconds — how long the link may stay in
+     * {@code DISCONNECTED_RETRYING} before {@link #shouldForceClose()} fires. Used by the caller to
+     * pace how often it re-evaluates {@code shouldForceClose()} while retrying.
+     */
+    public long getMaxRetryingMillis() {
+        return maxRetryingMillis;
+    }
+
+    public synchronized IotHubConnectionStatus getStatus() {
+        return status;
+    }
+
+    public synchronized IotHubConnectionStatusChangeReason getReason() {
+        return reason;
+    }
+
+    public synchronized Throwable getCause() {
+        return cause;
+    }
+
+    /**
+     * @return how long the link has been in {@code DISCONNECTED_RETRYING}, in milliseconds, or
+     * {@code 0} if it is not currently retrying.
+     */
+    public synchronized long getRetryingForMillis() {
+        if (retryingSinceMillis == 0L) {
+            return 0L;
+        }
+        return Math.max(0L, clockMillis.getAsLong() - retryingSinceMillis);
+    }
+}

--- a/src/main/java/no/cantara/realestate/azure/iot/IotHubConnectionUnstableException.java
+++ b/src/main/java/no/cantara/realestate/azure/iot/IotHubConnectionUnstableException.java
@@ -1,0 +1,70 @@
+package no.cantara.realestate.azure.iot;
+
+import com.microsoft.azure.sdk.iot.device.IotHubConnectionStatusChangeReason;
+import com.microsoft.azure.sdk.iot.device.transport.IotHubConnectionStatus;
+import no.cantara.realestate.ExceptionStatusType;
+import no.cantara.realestate.RealEstateException;
+
+/**
+ * Thrown by {@code AzureObservationDistributionClient.publish(..)} when the Azure IoT Hub link is
+ * unstable — the MQTT connection is down and the SDK is either retrying, has given up, or has been
+ * force-closed to break a reconnect loop.
+ *
+ * <p>This is the administrator alarm. The cause cannot be pinned down from the client side: a
+ * dropped link looks identical whether the network is down or the device message quota is exhausted
+ * (IoT Hub simply closes the connection in both cases). So the message says exactly that — "network
+ * down or quota exhausted, cannot determine which" — and carries the SDK's
+ * {@link IotHubConnectionStatus} and {@link IotHubConnectionStatusChangeReason} so an operator has
+ * the raw signal to investigate.
+ *
+ * <p>It carries {@link ExceptionStatusType#connection_error} rather than {@code RETRY_MAY_FIX_ISSUE}
+ * on purpose: while the link is unstable, having the upstream distributor retry immediately just
+ * piles more doomed sends onto a dead connection. New messages are rejected until the link recovers.
+ *
+ * @example
+ * <pre>{@code
+ * try {
+ *     distributionClient.publish(observation);
+ * } catch (IotHubConnectionUnstableException e) {
+ *     alerting.raise("IoT Hub link unstable: " + e.getMessage(),
+ *                    e.getConnectionStatus(), e.getReason());
+ * }
+ * }</pre>
+ */
+public class IotHubConnectionUnstableException extends RealEstateException {
+
+    private final IotHubConnectionStatus connectionStatus;
+    private final IotHubConnectionStatusChangeReason reason;
+    private final long retryingForMillis;
+
+    public IotHubConnectionUnstableException(IotHubConnectionStatus connectionStatus,
+                                             IotHubConnectionStatusChangeReason reason,
+                                             long retryingForMillis) {
+        super(buildMessage(connectionStatus, reason, retryingForMillis), ExceptionStatusType.connection_error);
+        this.connectionStatus = connectionStatus;
+        this.reason = reason;
+        this.retryingForMillis = retryingForMillis;
+    }
+
+    private static String buildMessage(IotHubConnectionStatus connectionStatus,
+                                       IotHubConnectionStatusChangeReason reason,
+                                       long retryingForMillis) {
+        return "Azure IoT Hub connection is unstable (status=" + connectionStatus
+                + ", reason=" + reason
+                + ", retryingForMs=" + retryingForMillis
+                + "). The network may be down or the device message quota may be exhausted — the client "
+                + "cannot determine which. New messages are being rejected until the link recovers.";
+    }
+
+    public IotHubConnectionStatus getConnectionStatus() {
+        return connectionStatus;
+    }
+
+    public IotHubConnectionStatusChangeReason getReason() {
+        return reason;
+    }
+
+    public long getRetryingForMillis() {
+        return retryingForMillis;
+    }
+}

--- a/src/main/java/no/cantara/realestate/azure/iot/MqttSendFailureClassifier.java
+++ b/src/main/java/no/cantara/realestate/azure/iot/MqttSendFailureClassifier.java
@@ -57,9 +57,14 @@ public final class MqttSendFailureClassifier {
             case INTERNAL_SERVER_ERROR:
             case IO_ERROR:
             case DEVICE_OPERATION_TIMED_OUT:
+                return MqttSendFailureType.TRANSIENT;
+
+            // The message is gone — the connection went away underneath it. Resending the same
+            // payload is pointless; when sending is already stopped this confirms a dead link
+            // (network down or quota exhausted). See MqttSendFailureType.UNDELIVERABLE.
             case MESSAGE_EXPIRED:
             case MESSAGE_CANCELLED_ONCLOSE:
-                return MqttSendFailureType.TRANSIENT;
+                return MqttSendFailureType.UNDELIVERABLE;
 
             // Permanent — retrying will not help; drop the message.
             case BAD_FORMAT:

--- a/src/main/java/no/cantara/realestate/azure/iot/MqttSendFailureType.java
+++ b/src/main/java/no/cantara/realestate/azure/iot/MqttSendFailureType.java
@@ -45,6 +45,17 @@ public enum MqttSendFailureType {
      */
     FATAL,
 
+    /**
+     * The message was dropped without ever being delivered because the client connection went away
+     * underneath it ({@code MESSAGE_CANCELLED_ONCLOSE} when the client closed,
+     * {@code MESSAGE_EXPIRED} when the SDK gave up retrying). The message is <strong>gone</strong> —
+     * resending the same payload is pointless. Crucially, seeing this <em>while sending is already
+     * stopped</em> (link unstable / force-closed) is the confirmation that the network is down or the
+     * device quota is exhausted, and is the trigger for alerting an administrator. Distinct from
+     * {@link #TRANSIENT} (which invites a retry) and from {@link #FATAL} (a bad message, not a dead link).
+     */
+    UNDELIVERABLE,
+
     /** The status code was missing or not recognised by this classifier. Treat conservatively. */
     UNKNOWN;
 

--- a/src/test/java/no/cantara/realestate/azure/AzureObservationDistributionClientCircuitTest.java
+++ b/src/test/java/no/cantara/realestate/azure/AzureObservationDistributionClientCircuitTest.java
@@ -28,6 +28,7 @@ class AzureObservationDistributionClientCircuitTest {
         azureDeviceClient = mock(AzureDeviceClient.class);
         when(azureDeviceClient.isConnectionEstablished()).thenReturn(true);
         distributionClient = new AzureObservationDistributionClient(azureDeviceClient);
+        distributionClient.setHealthy();
     }
 
     @Test

--- a/src/test/java/no/cantara/realestate/azure/AzureObservationDistributionClientDisconnectedTest.java
+++ b/src/test/java/no/cantara/realestate/azure/AzureObservationDistributionClientDisconnectedTest.java
@@ -60,6 +60,7 @@ class AzureObservationDistributionClientDisconnectedTest {
         // Default: a live connection, so publish() proceeds past the up-front guard.
         when(azureDeviceClient.isConnectionEstablished()).thenReturn(true);
         distributionClient = new RecordingBrakeClient(azureDeviceClient);
+        distributionClient.setHealthy();
     }
 
     /**
@@ -106,7 +107,7 @@ class AzureObservationDistributionClientDisconnectedTest {
 
         // The circuit does NOT open on multiple disconnects. The design decision is to use back-off policy.
         assertFalse(distributionClient.isSendingStopped());
-        assertTrue(distributionClient.isHealthy());
+        assertFalse(distributionClient.isHealthy());
     }
 
     /**
@@ -150,7 +151,7 @@ class AzureObservationDistributionClientDisconnectedTest {
     }
 
     /**
-     * Layer 2 — the situation in the log. The message was accepted while connected; the connection
+     * The message was accepted while connected; the connection
      * then dropped and the SDK exhausted its retries, delivering
      * {@code "Cannot publish when mqtt client is disconnected"} to our callback.
      *
@@ -168,7 +169,7 @@ class AzureObservationDistributionClientDisconnectedTest {
 
         // The circuit does NOT open on a disconnect.
         assertFalse(distributionClient.isSendingStopped());
-        assertTrue(distributionClient.isHealthy());
+        assertFalse(distributionClient.isHealthy());
         // No back-off either — a disconnect is not an overload.
         assertFalse(distributionClient.isThrottled());
         assertEquals(0, distributionClient.getConsecutiveOverloads());
@@ -178,50 +179,6 @@ class AzureObservationDistributionClientDisconnectedTest {
         assertEquals(0, distributionClient.getMessagesAwaitingSentAckCollection().size());
     }
 
-
-
-    /**
-     * Disconnect health and the hard stop are decoupled. Even a burst past {@link
-     * #MAX_CONSECUTIVE_CLIENT_DISCONNECT_ERRORS} keeps the circuit CLOSED and sending alive (the
-     * adaptive brake keeps retrying) — unlike {@code QUOTA_EXCEEDED}/{@code THROTTLED}, a disconnect
-     * never opens the circuit. What changes is the health signal: the client reports unhealthy so
-     * monitoring can alert, while still trying to deliver.
-     */
-    @Test
-    void repeatedDisconnects_reportUnhealthyButKeepSending() {
-        int tries = MAX_CONSECUTIVE_CLIENT_DISCONNECT_ERRORS + 1;
-        for (int i = 0; i < tries; i++) {
-            deliverFailureToCallback(disconnectFailure());
-        }
-
-        assertEquals(tries, distributionClient.getNumberOfMessagesFailed());
-        // Sending is NOT stopped: the circuit stays closed and the quota overload counter is untouched.
-        assertFalse(distributionClient.isSendingStopped());
-        assertEquals(0, distributionClient.getConsecutiveOverloads());
-        // But the sustained disconnect is surfaced as unhealthy.
-        assertFalse(distributionClient.isHealthy());
-    }
-
-    /**
-     * Option B (issue: connection-aware back-off). A short burst of disconnects is tolerated as a
-     * blip, but once they persist the client should brake the send rate — "wait a bit before
-     * sending more" — instead of firing messages straight into a dead link. The circuit stays
-     * CLOSED and health stays good; this is a soft brake, not a hard stop.
-     */
-    @Test
-    void persistentDisconnects_engageBackoff() {
-        for (int i = 0; i < 3; i++) {
-            deliverFailureToCallback(disconnectFailure());
-        }
-
-        assertTrue(distributionClient.isThrottled(),
-                "persistent disconnects should brake the send rate");
-        assertTrue(distributionClient.getThrottleBackoffMillis() > 0);
-        // A soft brake only: the circuit must not open and the quota overload counter is untouched.
-        assertFalse(distributionClient.isSendingStopped());
-        assertTrue(distributionClient.isHealthy());
-        assertEquals(0, distributionClient.getConsecutiveOverloads());
-    }
 
     /**
      * A single disconnect is treated as a blip — it does not brake yet. Braking only kicks in once

--- a/src/test/java/no/cantara/realestate/azure/AzureObservationDistributionClientUnstableLinkTest.java
+++ b/src/test/java/no/cantara/realestate/azure/AzureObservationDistributionClientUnstableLinkTest.java
@@ -1,0 +1,97 @@
+package no.cantara.realestate.azure;
+
+import com.microsoft.azure.sdk.iot.device.IotHubStatusCode;
+import com.microsoft.azure.sdk.iot.device.Message;
+import com.microsoft.azure.sdk.iot.device.MessageSentCallback;
+import com.microsoft.azure.sdk.iot.device.exceptions.IotHubClientException;
+import no.cantara.realestate.ExceptionStatusType;
+import no.cantara.realestate.azure.iot.AzureDeviceClient;
+import no.cantara.realestate.azure.iot.IotHubConnectionUnstableException;
+import no.cantara.realestate.azure.iot.MqttSendFailureType;
+import no.cantara.realestate.observations.ObservationMessage;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import static com.microsoft.azure.sdk.iot.device.IotHubConnectionStatusChangeReason.NO_NETWORK;
+import static com.microsoft.azure.sdk.iot.device.transport.IotHubConnectionStatus.DISCONNECTED_RETRYING;
+import static no.cantara.realestate.azure.AzureObservationDistributionClientTest.buildStubObservation;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+/**
+ * The "strup ny sending"/alarm behaviour: when the Azure IoT Hub link is unstable (network down or
+ * quota exhausted — indistinguishable from the client side, azure-iot-sdk-java#1805), {@code publish}
+ * stops sending and raises a typed {@link IotHubConnectionUnstableException}, and the client reports
+ * unhealthy so a reopen-watchdog can act.
+ */
+class AzureObservationDistributionClientUnstableLinkTest {
+
+    private AzureDeviceClient azureDeviceClient;
+    private AzureObservationDistributionClient distributionClient;
+
+    @BeforeEach
+    void setUp() {
+        azureDeviceClient = mock(AzureDeviceClient.class);
+        distributionClient = new AzureObservationDistributionClient(azureDeviceClient);
+    }
+
+    @Test
+    void unstableLink_publishRejectsWithTypedAlarmAndDoesNotReachSdk() {
+        when(azureDeviceClient.isConnectionEstablished()).thenReturn(false);
+        when(azureDeviceClient.isConnectionUnstable()).thenReturn(true);
+        when(azureDeviceClient.getConnectionStatus()).thenReturn(DISCONNECTED_RETRYING);
+        when(azureDeviceClient.getConnectionStatusReason()).thenReturn(NO_NETWORK);
+        when(azureDeviceClient.getConnectionRetryingForMillis()).thenReturn(5_000L);
+
+        IotHubConnectionUnstableException thrown = assertThrows(IotHubConnectionUnstableException.class,
+                () -> distributionClient.publish(buildStubObservation()));
+
+        // Typed alarm carries the raw SDK signal for the administrator.
+        assertEquals(DISCONNECTED_RETRYING, thrown.getConnectionStatus());
+        assertEquals(NO_NETWORK, thrown.getReason());
+        assertEquals(ExceptionStatusType.connection_error, thrown.getStatusType());
+        // Sending is stopped: the message never reaches the SDK and is counted as rejected.
+        verify(azureDeviceClient, never()).sendEventAsync(any(), any());
+        assertEquals(1, distributionClient.getNumberOfMessagesRejected());
+        // The link being unstable is surfaced as unhealthy for the reopen-watchdog.
+        assertFalse(distributionClient.isHealthy());
+    }
+
+    @Test
+    void notYetOpened_stillUsesPlainRetryableRefusal() {
+        // A not-yet-opened / cleanly-closed client is NOT an unstable link: keep the legacy refusal.
+        when(azureDeviceClient.isConnectionEstablished()).thenReturn(false);
+        when(azureDeviceClient.isConnectionUnstable()).thenReturn(false);
+
+        no.cantara.realestate.RealEstateException thrown = assertThrows(no.cantara.realestate.RealEstateException.class,
+                () -> distributionClient.publish(buildStubObservation()));
+
+        assertFalse(thrown instanceof IotHubConnectionUnstableException);
+        assertEquals(ExceptionStatusType.RETRY_MAY_FIX_ISSUE, thrown.getStatusType());
+    }
+
+    @Test
+    void cancelledOnClose_isUndeliverableNotRetried() {
+        // While connected, a send is accepted; the connection then closes underneath it and the SDK
+        // reports MESSAGE_CANCELLED_ONCLOSE — the message is gone, classified UNDELIVERABLE.
+        when(azureDeviceClient.isConnectionEstablished()).thenReturn(true);
+
+        ObservationMessage observation = buildStubObservation();
+        distributionClient.publish(observation);
+
+        ArgumentCaptor<Message> messageCaptor = ArgumentCaptor.forClass(Message.class);
+        ArgumentCaptor<MessageSentCallback> callbackCaptor = ArgumentCaptor.forClass(MessageSentCallback.class);
+        verify(azureDeviceClient).sendEventAsync(messageCaptor.capture(), callbackCaptor.capture());
+        Message sentMessage = messageCaptor.getValue();
+        callbackCaptor.getValue().onMessageSent(sentMessage,
+                new IotHubClientException(IotHubStatusCode.MESSAGE_CANCELLED_ONCLOSE, "cancelled on close"),
+                sentMessage);
+
+        assertEquals(MqttSendFailureType.UNDELIVERABLE, distributionClient.getLastFailureType());
+        assertEquals(1, distributionClient.getNumberOfMessagesFailed(MqttSendFailureType.UNDELIVERABLE));
+        assertFalse(distributionClient.getLastFailureType().isRetryable());
+        assertEquals(0, distributionClient.getNumberOfMessagesPublished());
+    }
+}

--- a/src/test/java/no/cantara/realestate/azure/AzureObservationDistributionClientUnstableLinkTest.java
+++ b/src/test/java/no/cantara/realestate/azure/AzureObservationDistributionClientUnstableLinkTest.java
@@ -6,7 +6,7 @@ import com.microsoft.azure.sdk.iot.device.MessageSentCallback;
 import com.microsoft.azure.sdk.iot.device.exceptions.IotHubClientException;
 import no.cantara.realestate.ExceptionStatusType;
 import no.cantara.realestate.azure.iot.AzureDeviceClient;
-import no.cantara.realestate.azure.iot.IotHubConnectionUnstableException;
+import no.cantara.realestate.azure.iot.AzureIotHubConnectionUnstableException;
 import no.cantara.realestate.azure.iot.MqttSendFailureType;
 import no.cantara.realestate.observations.ObservationMessage;
 import org.junit.jupiter.api.BeforeEach;
@@ -23,7 +23,7 @@ import static org.mockito.Mockito.*;
 /**
  * The "strup ny sending"/alarm behaviour: when the Azure IoT Hub link is unstable (network down or
  * quota exhausted — indistinguishable from the client side, azure-iot-sdk-java#1805), {@code publish}
- * stops sending and raises a typed {@link IotHubConnectionUnstableException}, and the client reports
+ * stops sending and raises a typed {@link AzureIotHubConnectionUnstableException}, and the client reports
  * unhealthy so a reopen-watchdog can act.
  */
 class AzureObservationDistributionClientUnstableLinkTest {
@@ -45,7 +45,7 @@ class AzureObservationDistributionClientUnstableLinkTest {
         when(azureDeviceClient.getConnectionStatusReason()).thenReturn(NO_NETWORK);
         when(azureDeviceClient.getConnectionRetryingForMillis()).thenReturn(5_000L);
 
-        IotHubConnectionUnstableException thrown = assertThrows(IotHubConnectionUnstableException.class,
+        AzureIotHubConnectionUnstableException thrown = assertThrows(AzureIotHubConnectionUnstableException.class,
                 () -> distributionClient.publish(buildStubObservation()));
 
         // Typed alarm carries the raw SDK signal for the administrator.
@@ -78,7 +78,7 @@ class AzureObservationDistributionClientUnstableLinkTest {
         no.cantara.realestate.RealEstateException thrown = assertThrows(no.cantara.realestate.RealEstateException.class,
                 () -> distributionClient.publish(buildStubObservation()));
 
-        assertFalse(thrown instanceof IotHubConnectionUnstableException);
+        assertFalse(thrown instanceof AzureIotHubConnectionUnstableException);
         assertEquals(ExceptionStatusType.RETRY_MAY_FIX_ISSUE, thrown.getStatusType());
     }
 

--- a/src/test/java/no/cantara/realestate/azure/AzureObservationDistributionClientUnstableLinkTest.java
+++ b/src/test/java/no/cantara/realestate/azure/AzureObservationDistributionClientUnstableLinkTest.java
@@ -5,6 +5,7 @@ import com.microsoft.azure.sdk.iot.device.Message;
 import com.microsoft.azure.sdk.iot.device.MessageSentCallback;
 import com.microsoft.azure.sdk.iot.device.exceptions.IotHubClientException;
 import no.cantara.realestate.ExceptionStatusType;
+import no.cantara.realestate.MqttUnavailableException;
 import no.cantara.realestate.azure.iot.AzureDeviceClient;
 import no.cantara.realestate.azure.iot.AzureIotHubConnectionUnstableException;
 import no.cantara.realestate.azure.iot.MqttSendFailureType;
@@ -45,13 +46,14 @@ class AzureObservationDistributionClientUnstableLinkTest {
         when(azureDeviceClient.getConnectionStatusReason()).thenReturn(NO_NETWORK);
         when(azureDeviceClient.getConnectionRetryingForMillis()).thenReturn(5_000L);
 
-        AzureIotHubConnectionUnstableException thrown = assertThrows(AzureIotHubConnectionUnstableException.class,
+        MqttUnavailableException thrown = assertThrows(MqttUnavailableException.class,
                 () -> distributionClient.publish(buildStubObservation()));
 
         // Typed alarm carries the raw SDK signal for the administrator.
-        assertEquals(DISCONNECTED_RETRYING, thrown.getConnectionStatus());
-        assertEquals(NO_NETWORK, thrown.getReason());
-        assertEquals(ExceptionStatusType.connection_error, thrown.getStatusType());
+        AzureIotHubConnectionUnstableException cause = (AzureIotHubConnectionUnstableException) thrown.getCause();
+        assertEquals(DISCONNECTED_RETRYING, cause.getConnectionStatus());
+        assertEquals(NO_NETWORK, cause.getReason());
+        assertEquals(ExceptionStatusType.RETRY_NOT_POSSIBLE, thrown.getStatusType());
         // Sending is stopped: the message never reaches the SDK and is counted as rejected.
         verify(azureDeviceClient, never()).sendEventAsync(any(), any());
         assertEquals(1, distributionClient.getNumberOfMessagesRejected());

--- a/src/test/java/no/cantara/realestate/azure/AzureObservationDistributionClientUnstableLinkTest.java
+++ b/src/test/java/no/cantara/realestate/azure/AzureObservationDistributionClientUnstableLinkTest.java
@@ -57,6 +57,16 @@ class AzureObservationDistributionClientUnstableLinkTest {
         assertEquals(1, distributionClient.getNumberOfMessagesRejected());
         // The link being unstable is surfaced as unhealthy for the reopen-watchdog.
         assertFalse(distributionClient.isHealthy());
+        // ...and as a single "sending stopped" signal, regardless of which source stopped it, so an
+        // external caller can poll this and reopen the connection without knowing the internals.
+        assertTrue(distributionClient.isSendingStopped());
+    }
+
+    @Test
+    void stableLink_sendingNotStopped() {
+        when(azureDeviceClient.isConnectionUnstable()).thenReturn(false);
+
+        assertFalse(distributionClient.isSendingStopped());
     }
 
     @Test

--- a/src/test/java/no/cantara/realestate/azure/ConnectionStabilityTest.java
+++ b/src/test/java/no/cantara/realestate/azure/ConnectionStabilityTest.java
@@ -1,8 +1,8 @@
-package no.cantara.realestate.azure.iot;
+package no.cantara.realestate.azure;
 
 import com.microsoft.azure.sdk.iot.device.IotHubClientProtocol;
 import no.cantara.config.ApplicationProperties;
-import no.cantara.realestate.azure.AzureObservationDistributionClient;
+import no.cantara.realestate.azure.iot.AzureDeviceClient;
 import no.cantara.realestate.observations.ObservationMessage;
 import no.cantara.realestate.observations.ObservationMessageBuilder;
 import org.slf4j.Logger;

--- a/src/test/java/no/cantara/realestate/azure/iot/AzureDeviceClientConnectionMonitorTest.java
+++ b/src/test/java/no/cantara/realestate/azure/iot/AzureDeviceClientConnectionMonitorTest.java
@@ -1,0 +1,72 @@
+package no.cantara.realestate.azure.iot;
+
+import com.microsoft.azure.sdk.iot.device.DeviceClient;
+import org.junit.jupiter.api.Test;
+
+import static com.microsoft.azure.sdk.iot.device.IotHubConnectionStatusChangeReason.*;
+import static com.microsoft.azure.sdk.iot.device.transport.IotHubConnectionStatus.*;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class AzureDeviceClientConnectionMonitorTest {
+
+    @Test
+    void connectedStatusMarksConnectionEstablishedAndStable() {
+        AzureDeviceClient client = new AzureDeviceClient(mock(DeviceClient.class));
+
+        client.handleConnectionStatusChange(CONNECTED, CONNECTION_OK, null);
+
+        assertTrue(client.isConnectionEstablished());
+        assertFalse(client.isConnectionUnstable());
+    }
+
+    @Test
+    void retryingMarksUnstableButDoesNotForceClose() {
+        DeviceClient deviceClient = mock(DeviceClient.class);
+        AzureDeviceClient client = new AzureDeviceClient(deviceClient);
+
+        client.handleConnectionStatusChange(DISCONNECTED_RETRYING, NO_NETWORK, new RuntimeException("blip"));
+
+        assertFalse(client.isConnectionEstablished());
+        assertTrue(client.isConnectionUnstable());
+        // A blip within the retry budget must not close the client.
+        verify(deviceClient, after(300).never()).close();
+    }
+
+    @Test
+    void sdkGivingUpForceClosesTheClientOffTheCallbackThread() {
+        DeviceClient deviceClient = mock(DeviceClient.class);
+        AzureDeviceClient client = new AzureDeviceClient(deviceClient);
+
+        // The SDK exhausted its reconnect attempts — this is the trigger to break the loop.
+        client.handleConnectionStatusChange(DISCONNECTED, RETRY_EXPIRED, new RuntimeException("retries exhausted"));
+
+        // close() runs on a separate daemon thread; await it.
+        verify(deviceClient, timeout(2000)).close();
+        assertTrue(client.isConnectionUnstable());
+        assertFalse(client.isConnectionEstablished());
+    }
+
+    @Test
+    void stuckRetryingPastBudgetIsForceClosedByTheWatchdog() {
+        DeviceClient deviceClient = mock(DeviceClient.class);
+        // Short retry budget so the watchdog poll reaches it quickly; the SDK never sends a second
+        // status callback, so only the timer can trigger the close.
+        AzureDeviceClient client = new AzureDeviceClient(deviceClient, new IotHubConnectionMonitor(200L));
+
+        client.handleConnectionStatusChange(DISCONNECTED_RETRYING, NO_NETWORK, new RuntimeException("stuck"));
+
+        // No further status change arrives — the watchdog must still force the close once the budget elapses.
+        verify(deviceClient, timeout(3000)).close();
+        assertTrue(client.isConnectionUnstable());
+    }
+
+    @Test
+    void cleanCloseIsNotReportedAsUnstable() {
+        AzureDeviceClient client = new AzureDeviceClient(mock(DeviceClient.class));
+
+        client.handleConnectionStatusChange(DISCONNECTED, CLIENT_CLOSE, null);
+
+        assertFalse(client.isConnectionUnstable());
+    }
+}

--- a/src/test/java/no/cantara/realestate/azure/iot/AzureDeviceClientConnectionMonitorTest.java
+++ b/src/test/java/no/cantara/realestate/azure/iot/AzureDeviceClientConnectionMonitorTest.java
@@ -3,9 +3,12 @@ package no.cantara.realestate.azure.iot;
 import com.microsoft.azure.sdk.iot.device.DeviceClient;
 import org.junit.jupiter.api.Test;
 
+import java.util.concurrent.atomic.AtomicLong;
+
 import static com.microsoft.azure.sdk.iot.device.IotHubConnectionStatusChangeReason.*;
 import static com.microsoft.azure.sdk.iot.device.transport.IotHubConnectionStatus.*;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.*;
 
 class AzureDeviceClientConnectionMonitorTest {
@@ -48,17 +51,40 @@ class AzureDeviceClientConnectionMonitorTest {
     }
 
     @Test
-    void stuckRetryingPastBudgetIsForceClosedByTheWatchdog() {
+    void repeatedRetryingPastBudgetForcesClose() {
         DeviceClient deviceClient = mock(DeviceClient.class);
-        // Short retry budget so the watchdog poll reaches it quickly; the SDK never sends a second
-        // status callback, so only the timer can trigger the close.
-        AzureDeviceClient client = new AzureDeviceClient(deviceClient, new IotHubConnectionMonitor(200L));
+        AtomicLong clock = new AtomicLong(1_000L);
+        // 60s budget with a controllable clock; the SDK re-fires DISCONNECTED_RETRYING on each attempt.
+        AzureDeviceClient client = new AzureDeviceClient(deviceClient, new IotHubConnectionMonitor(60_000L, clock::get));
 
-        client.handleConnectionStatusChange(DISCONNECTED_RETRYING, NO_NETWORK, new RuntimeException("stuck"));
+        // First retry: the budget clock starts, nothing closes yet.
+        client.handleConnectionStatusChange(DISCONNECTED_RETRYING, NO_NETWORK, new RuntimeException("blip"));
+        verify(deviceClient, after(200).never()).close();
 
-        // No further status change arrives — the watchdog must still force the close once the budget elapses.
-        verify(deviceClient, timeout(3000)).close();
+        // Time passes beyond the budget; the next retry callback re-evaluates and breaks the loop.
+        clock.addAndGet(60_000L);
+        client.handleConnectionStatusChange(DISCONNECTED_RETRYING, NO_NETWORK, new RuntimeException("still stuck"));
+
+        // close() runs on a separate daemon thread; await it.
+        verify(deviceClient, timeout(2000)).close();
         assertTrue(client.isConnectionUnstable());
+    }
+
+    @Test
+    void successfulSendResetsTheRetryBudget() {
+        DeviceClient deviceClient = mock(DeviceClient.class);
+        AtomicLong clock = new AtomicLong(1_000L);
+        AzureDeviceClient client = new AzureDeviceClient(deviceClient, new IotHubConnectionMonitor(60_000L, clock::get));
+
+        client.handleConnectionStatusChange(DISCONNECTED_RETRYING, NO_NETWORK, new RuntimeException("blip"));
+        clock.addAndGet(50_000L);
+        // A message got through — the link is alive, so the budget restarts from here.
+        client.notifyMessageDelivered();
+
+        // Another retry arrives; only 20s have elapsed since the reset, so no close yet.
+        clock.addAndGet(20_000L);
+        client.handleConnectionStatusChange(DISCONNECTED_RETRYING, NO_NETWORK, new RuntimeException("again"));
+        verify(deviceClient, after(200).never()).close();
     }
 
     @Test

--- a/src/test/java/no/cantara/realestate/azure/iot/IotHubConnectionMonitorTest.java
+++ b/src/test/java/no/cantara/realestate/azure/iot/IotHubConnectionMonitorTest.java
@@ -1,0 +1,103 @@
+package no.cantara.realestate.azure.iot;
+
+import com.microsoft.azure.sdk.iot.device.IotHubConnectionStatusChangeReason;
+import com.microsoft.azure.sdk.iot.device.transport.IotHubConnectionStatus;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.atomic.AtomicLong;
+
+import static com.microsoft.azure.sdk.iot.device.IotHubConnectionStatusChangeReason.*;
+import static com.microsoft.azure.sdk.iot.device.transport.IotHubConnectionStatus.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+class IotHubConnectionMonitorTest {
+
+    private final AtomicLong clock = new AtomicLong(1_000L);
+    private final IotHubConnectionMonitor monitor = new IotHubConnectionMonitor(300_000L, clock::get);
+
+    @Test
+    void freshMonitorIsStableAndDoesNotClose() {
+        // Never opened: DISCONNECTED with no reason is not "unstable" and must not trigger a close.
+        assertFalse(monitor.isLinkUnstable());
+        assertFalse(monitor.isConnectionUnstableOrStopped());
+        assertFalse(monitor.shouldForceClose());
+    }
+
+    @Test
+    void connectedIsHealthy() {
+        monitor.recordStatusChange(CONNECTED, CONNECTION_OK, null);
+        assertFalse(monitor.isLinkUnstable());
+        assertFalse(monitor.shouldForceClose());
+        assertEquals(0L, monitor.getRetryingForMillis());
+    }
+
+    @Test
+    void retryingIsUnstableButToleratedWithinBudget() {
+        monitor.recordStatusChange(DISCONNECTED_RETRYING, NO_NETWORK, new RuntimeException("link lost"));
+
+        assertTrue(monitor.isLinkUnstable());
+        assertTrue(monitor.isConnectionUnstableOrStopped());
+        // A blip: still within the retry budget, so do not force a close yet.
+        clock.addAndGet(60_000L);
+        assertFalse(monitor.shouldForceClose());
+        assertEquals(60_000L, monitor.getRetryingForMillis());
+    }
+
+    @Test
+    void retryingPastBudgetForcesClose() {
+        monitor.recordStatusChange(DISCONNECTED_RETRYING, NO_NETWORK, null);
+        clock.addAndGet(300_000L); // reach the budget
+        assertTrue(monitor.shouldForceClose(), "stuck retrying past the budget must force a close");
+    }
+
+    @Test
+    void retryExpiredForcesCloseImmediately() {
+        // The SDK gave up on its own — close now to release the threads and flush the queue.
+        monitor.recordStatusChange(DISCONNECTED, RETRY_EXPIRED, new RuntimeException("retries exhausted"));
+        assertTrue(monitor.shouldForceClose());
+    }
+
+    @Test
+    void cleanClientCloseIsNotUnstable() {
+        // A deliberate close (our own closeConnection) must not be mistaken for instability.
+        monitor.recordStatusChange(DISCONNECTED, CLIENT_CLOSE, null);
+        assertFalse(monitor.isLinkUnstable());
+        assertFalse(monitor.shouldForceClose());
+    }
+
+    @Test
+    void forceCloseFiresOnlyOnce() {
+        monitor.recordStatusChange(DISCONNECTED, RETRY_EXPIRED, null);
+        assertTrue(monitor.shouldForceClose());
+
+        monitor.markClosedDueToInstability();
+        assertFalse(monitor.shouldForceClose(), "must not keep asking to close once marked");
+        assertTrue(monitor.isClosedDueToInstability());
+        assertTrue(monitor.isConnectionUnstableOrStopped());
+    }
+
+    @Test
+    void recoveryClearsForceCloseState() {
+        monitor.recordStatusChange(DISCONNECTED, RETRY_EXPIRED, null);
+        monitor.markClosedDueToInstability();
+        assertTrue(monitor.isConnectionUnstableOrStopped());
+
+        // Watchdog reopened and the link came back.
+        monitor.recordStatusChange(CONNECTED, CONNECTION_OK, null);
+        assertFalse(monitor.isClosedDueToInstability());
+        assertFalse(monitor.isConnectionUnstableOrStopped());
+        assertFalse(monitor.shouldForceClose());
+    }
+
+    @Test
+    void retryClockResetsAfterReconnect() {
+        monitor.recordStatusChange(DISCONNECTED_RETRYING, NO_NETWORK, null);
+        clock.addAndGet(120_000L);
+        monitor.recordStatusChange(CONNECTED, CONNECTION_OK, null);
+        // A later, separate retry starts its budget fresh — the earlier 120s does not carry over.
+        monitor.recordStatusChange(DISCONNECTED_RETRYING, NO_NETWORK, null);
+        clock.addAndGet(60_000L);
+        assertFalse(monitor.shouldForceClose());
+        assertEquals(60_000L, monitor.getRetryingForMillis());
+    }
+}

--- a/src/test/java/no/cantara/realestate/azure/iot/MqttIotHubDailyLimitManualTest.java
+++ b/src/test/java/no/cantara/realestate/azure/iot/MqttIotHubDailyLimitManualTest.java
@@ -37,8 +37,8 @@ class MqttIotHubDailyLimitManualTest {
 
     public static void main(String[] args) throws InterruptedException, JsonProcessingException {
         boolean useConfig = true;
-        boolean runInBatch = true;
-        int cleanupPeriodSec = 240;
+        boolean runInBatch = false;
+        int cleanupPeriodSec = 360;//240;
         LoggerContext context = (LoggerContext) LoggerFactory.getILoggerFactory();
         context.getLogger("no.cantara").setLevel(Level.INFO);
         context.getLogger("no.cantara.realestate.azure.iot.MqttIotHubDailyLimitManualTest").setLevel(Level.TRACE);
@@ -79,7 +79,7 @@ class MqttIotHubDailyLimitManualTest {
                     distributionClient.publish(observationMessage);
                     Thread.sleep(100);
                     assertFalse(true, "Should have thrown Exception");
-                } catch (IotHubConnectionUnstableException e) {
+                } catch (AzureIotHubConnectionUnstableException e) {
                     log.info("Expected exception: {}", e.getMessage());
                 }
             }
@@ -99,6 +99,7 @@ class MqttIotHubDailyLimitManualTest {
         log.info("Waiting for replies for {} seconds.", cleanupPeriodSec);
         Thread.sleep(cleanupPeriodSec * 1000);
         log.info("Published a total of: {}", distributionClient.getNumberOfMessagesPublished());
+        log.warn("Will terminate the connection after an elapsed waitingperiod of {} seconds.", cleanupPeriodSec);
         distributionClient.closeConnection();
         assertFalse(distributionClient.isConnectionEstablished());
         assertFalse(distributionClient.isHealthy(), "The client should have reported unhealthy.");

--- a/src/test/java/no/cantara/realestate/azure/iot/MqttIotHubDailyLimitManualTest.java
+++ b/src/test/java/no/cantara/realestate/azure/iot/MqttIotHubDailyLimitManualTest.java
@@ -1,0 +1,168 @@
+package no.cantara.realestate.azure.iot;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.LoggerContext;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.microsoft.azure.sdk.iot.device.Message;
+import com.microsoft.azure.sdk.iot.device.MessageType;
+import no.cantara.config.ApplicationProperties;
+import no.cantara.realestate.RealEstateException;
+import no.cantara.realestate.azure.AzureObservationDistributionClient;
+import no.cantara.realestate.azure.rec.RecObservationMessage;
+import no.cantara.realestate.json.RealEstateObjectMapper;
+import no.cantara.realestate.observations.ObservationMessage;
+import no.cantara.realestate.observations.ObservationMessageBuilder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.util.Random;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.slf4j.LoggerFactory.getLogger;
+
+/**
+ * Verify the situation when daily rate limit is reached.
+ * run with -Dlogback.configurationFile=./src/test/resources/logback-test.xml
+ */
+class MqttIotHubDailyLimitManualTest {
+    private static final Logger log = getLogger(MqttIotHubDailyLimitManualTest.class);
+
+    public static final int DAILY_LIMIT = 400000;
+    public static final int BATCH_SIZE = 1000;
+    private static final String SIMULATOR_CONNECTIONSTRING_KEY = "simulator.azure.connectionString";
+
+    public static void main(String[] args) throws InterruptedException, JsonProcessingException {
+        boolean useConfig = true;
+        boolean runInBatch = true;
+        int cleanupPeriodSec = 240;
+        LoggerContext context = (LoggerContext) LoggerFactory.getILoggerFactory();
+        context.getLogger("no.cantara").setLevel(Level.INFO);
+        context.getLogger("no.cantara.realestate.azure.iot.MqttIotHubDailyLimitManualTest").setLevel(Level.TRACE);
+        context.getLogger("com.microsoft.azure.sdk.iot").setLevel(Level.ERROR);
+
+        AzureObservationDistributionClient distributionClient = createClient(args, useConfig);
+        distributionClient.openConnection();
+        assertTrue(distributionClient.isConnectionEstablished());
+        log.info("Connection is established.");
+
+        Thread.sleep(500);
+
+        try {
+            if (runInBatch) {
+                int iter = 1;
+                int max = 10;
+                do {
+                    log.info("Next iteration {} of {}", iter, max);
+                    for (int i = 0; i < BATCH_SIZE; i++) {
+                        ObservationMessage observationMessage = createTestMessage();
+                        distributionClient.publish(observationMessage);
+                    }
+                    while (distributionClient.getNumberOfMessagesInQueue() > 0) {
+                        long queuedCount = distributionClient.getNumberOfMessagesInQueue();
+                        long publishedCount = distributionClient.getNumberOfMessagesPublished();
+                        log.debug("Messages in queue: {}, published: {}", queuedCount, publishedCount);
+                        Thread.sleep(1000);
+                    }
+                    iter++;
+
+                } while (iter <= max);
+            } else {
+                ObservationMessage observationMessage = createTestMessage();
+                distributionClient.publish(observationMessage);
+                Thread.sleep(500);
+                try {
+                    observationMessage = createTestMessage();
+                    distributionClient.publish(observationMessage);
+                    Thread.sleep(100);
+                    assertFalse(true, "Should have thrown Exception");
+                } catch (IotHubConnectionUnstableException e) {
+                    log.info("Expected exception: {}", e.getMessage());
+                }
+            }
+        } catch (RealEstateException e) {
+            log.error("RealEstateException: {}", e.getMessage(), e);
+            long messagesInQueue = distributionClient.getNumberOfMessagesInQueue();
+            long messagesPublishec = distributionClient.getNumberOfMessagesPublished();
+            long messagesObserved = distributionClient.getNumberOfMessagesObserved();
+            boolean isClientHealthy = distributionClient.isHealthy();
+            boolean isDistributionThrottled = distributionClient.isThrottled();
+            boolean isSendingStopped = distributionClient.isSendingStopped();
+            log.info("Messages in queue: {}, published: {}, observed: {}, isClientHealthy: {}, isDistributionThrottled: {}, isSendingStopped: {}",
+                    messagesInQueue, messagesPublishec, messagesObserved, isClientHealthy, isDistributionThrottled, isSendingStopped);
+        }
+
+        //Closing connection
+        log.info("Waiting for replies for {} seconds.", cleanupPeriodSec);
+        Thread.sleep(cleanupPeriodSec * 1000);
+        log.info("Published a total of: {}", distributionClient.getNumberOfMessagesPublished());
+        distributionClient.closeConnection();
+        assertFalse(distributionClient.isConnectionEstablished());
+        assertFalse(distributionClient.isHealthy(), "The client should have reported unhealthy.");
+        log.info("DONE-Connection is closed.");
+    }
+
+    protected static AzureObservationDistributionClient createClient(String[] args, Boolean useConfig) {
+        AzureObservationDistributionClient distributionClient = null;
+        ApplicationProperties config;
+        if (useConfig) {
+            config = ApplicationProperties.builder()
+                    .defaults()
+                    .buildAndSetStaticSingleton();
+
+//            deviceClient = new AzureDeviceClient(config.get(SIMULATOR_CONNECTIONSTRING_KEY));
+            distributionClient = new AzureObservationDistributionClient(config.get(SIMULATOR_CONNECTIONSTRING_KEY));
+        } else {
+            if (args.length < 1) {
+                log.error("You need to provide \"primary connection string\" from a Device registered in Azure IoTHub.\n" +
+                        "Enter this string as the first argument when running this class.");
+                System.exit(0);
+            }
+            String connectionString = args[0];
+            log.debug("ConnectionString {}", connectionString);
+            distributionClient = new AzureObservationDistributionClient(connectionString);
+            //deviceClient = new AzureDeviceClient(connectionString);
+        }
+        return distributionClient;
+    }
+
+    protected static Message buildTelemetryMessage(ObservationMessage observationMessage) throws JsonProcessingException {
+
+        RecObservationMessage recObservationMessage = new RecObservationMessage(observationMessage);
+        String observationJson = RealEstateObjectMapper.getInstance().getObjectMapper().writeValueAsString(recObservationMessage);
+        log.trace("Publishing RecObservationMessage: {}", observationJson);
+        Message telemetryMessage = new Message(observationJson);
+        String messageId = UUID.randomUUID().toString();
+        telemetryMessage.setMessageId(messageId);
+        telemetryMessage.setMessageType(MessageType.DEVICE_TELEMETRY);
+        telemetryMessage.setContentEncoding(StandardCharsets.UTF_8.name());
+        telemetryMessage.setContentType("application/json");
+        return telemetryMessage;
+    }
+
+    private static ObservationMessage createTestMessage() {
+        final Random random = new Random();
+        Instant now = Instant.now();
+        String sensorId = "mqtt-error-simulator-sensor-" + random.nextInt(5);
+        double temperature = 18.0 + random.nextDouble() * 12; // 18-30°C
+
+        return new ObservationMessageBuilder()
+                .withSensorId(sensorId)
+                .withRealEstate("StabilityTestRE")
+                .withBuilding("TestBuilding")
+                .withFloor(String.format("%02d", 1 + random.nextInt(3)))
+                .withSection("Section-" + (char) ('A' + random.nextInt(3)))
+                .withServesRoom("Room-" + (100 + random.nextInt(10)))
+                .withSensorType("temp")
+                .withMeasurementUnit("C")
+                .withValue(temperature)
+                .withObservationTime(now.minusSeconds(random.nextInt(30)))
+                .withReceivedAt(now)
+                .withTfm("TFM-STABILITY-TEST")
+                .build();
+    }
+
+}

--- a/src/test/java/no/cantara/realestate/azure/iot/MqttSendFailureClassifierTest.java
+++ b/src/test/java/no/cantara/realestate/azure/iot/MqttSendFailureClassifierTest.java
@@ -40,6 +40,14 @@ class MqttSendFailureClassifierTest {
     }
 
     @Test
+    void cancelledOnCloseAndExpiredAreUndeliverable() {
+        // The message went away with the connection — not a retry candidate. Seeing this while
+        // sending is stopped confirms a dead link (network down or quota exhausted).
+        assertEquals(MqttSendFailureType.UNDELIVERABLE, MqttSendFailureClassifier.classify(IotHubStatusCode.MESSAGE_CANCELLED_ONCLOSE));
+        assertEquals(MqttSendFailureType.UNDELIVERABLE, MqttSendFailureClassifier.classify(IotHubStatusCode.MESSAGE_EXPIRED));
+    }
+
+    @Test
     void clientErrorsAreFatal() {
         assertEquals(MqttSendFailureType.FATAL, MqttSendFailureClassifier.classify(IotHubStatusCode.BAD_FORMAT));
         assertEquals(MqttSendFailureType.FATAL, MqttSendFailureClassifier.classify(IotHubStatusCode.UNAUTHORIZED));
@@ -67,5 +75,7 @@ class MqttSendFailureClassifierTest {
         assertTrue(MqttSendFailureType.TRANSIENT.isRetryable());
         assertFalse(MqttSendFailureType.QUOTA_EXCEEDED.isRetryable(), "retrying a quota failure makes the self-DoS worse");
         assertFalse(MqttSendFailureType.FATAL.isRetryable());
+        assertFalse(MqttSendFailureType.UNDELIVERABLE.isRetryable(), "an undeliverable message is gone — resending the same payload is pointless");
+        assertFalse(MqttSendFailureType.UNDELIVERABLE.isOverload());
     }
 }

--- a/src/test/resources/logback-test.xml
+++ b/src/test/resources/logback-test.xml
@@ -4,11 +4,12 @@
         <!-- encoders are assigned the type
              ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
         <encoder>
-            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+            <pattern>%d{yyyy-MM-dd'T'HH:mm:ss.SSSX,UTC} [%thread] %-5level %logger{36} - %msg%n</pattern>
         </encoder>
     </appender>
 
     <logger name="no.cantara" level="trace" />
+    <logger name="no.cantara.realestate.azure.iot" level="trace" />
     <root level="info">
         <appender-ref ref="STDOUT" />
     </root>


### PR DESCRIPTION
## Why

When the device message quota is exhausted (or the network drops), IoT Hub closes the MQTT link and the Azure SDK retries silently on its own threads. The per-message send callback never sees it, so the failure "just spins" with no way for the application to react — documented as "won't fix" in [azure-iot-sdk-java#1805](https://github.com/Azure/azure-iot-sdk-java/issues/1805) (intended reconnect window ~4 min, [#377](https://github.com/Azure/azure-iot-sdk-java/issues/377)). The two root causes (network down vs. quota exhausted) are indistinguishable from the client side, so this work **detects the instability and alarms/stops**, rather than trying to classify it.

## What

- **`IotHubConnectionMonitor`** — tracks the SDK's connection-status callback. Decides a force-close when recovery is no longer plausible: `DISCONNECTED/RETRY_EXPIRED`, or stuck in `DISCONNECTED_RETRYING` past a retry budget (default 60s). Clock-injectable for tests.
- **`AzureDeviceClient`** — registers `setConnectionStatusChangeCallback`, mirrors link state onto `connectionEstablished`, and force-closes on a separate daemon thread (`close()` joins the callback thread, so inline would deadlock). Re-evaluation is driven by the repeated `DISCONNECTED_RETRYING` callbacks (no scheduler). A `CONNECTED` event or a successfully delivered message clears the retry clock.
- **`publish()`** stops sending into a dead link and raises a typed alarm (`AzureIotHubConnectionUnstableException` wrapped in `MqttUnavailableException`) carrying the SDK status/reason — "network down or quota exhausted, cannot tell which".
- **`isHealthy()`** is now an explicit flag set by the send outcome (healthy on a delivered message, unhealthy on a send failure) combined with the live link state — the signal for an external reopen/ping.
- **`isSendingStopped()`** returns true from either source (circuit open **or** unstable link), so a caller can poll one predicate and reopen the connection without knowing the internals.
- **`MqttSendFailureType.UNDELIVERABLE`** (not retryable) — `MESSAGE_CANCELLED_ONCLOSE` / `MESSAGE_EXPIRED` mean the message is gone, not a retry candidate.

## Notes / follow-ups

- A flapping link (brief `CONNECTED` between drops, as during quota exhaustion) resets the 60s budget by design — whether that needs a "sustained reconnection" grace period is an open design question being evaluated separately.
- The actual reopen-watchdog (reopen with backoff) is left to the consumer; `isHealthy()` / `isSendingStopped()` are the agreed handoff signals.
- Retry budget is a constant for now (config-driven thresholds tracked under #447).

Test infra: manual reproduction harness, logback trace + UTC timestamps for the SDK loggers. Full suite green (68 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)